### PR TITLE
fix: 賣出交易與已實現損益原子性保障 (#12)

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -330,7 +330,7 @@ func startDiscordBot(cashFlowSvc service.CashFlowService, categoryRepo repositor
 	acctLoader := discordbot.NewAccountRepoAdapter(bankAccountRepo, creditCardRepo)
 	cfQuerier := discordbot.NewCashFlowQueryAdapter(cashFlowSvc)
 	acctBalQuerier := discordbot.NewAccountBalanceQueryAdapter(bankAccountRepo, creditCardRepo)
-	ccPaymentAdapter := discordbot.NewCreditCardPaymentAdapter(cashFlowSvc, creditCardRepo)
+	ccPaymentAdapter := discordbot.NewCreditCardPaymentAdapter(cashFlowSvc, creditCardRepo, categoryRepo)
 	handler := discordbot.NewHandler(parser, creator, catLoader, acctLoader, cfg.Lang,
 		discordbot.WithCashFlowQuerier(cfQuerier),
 		discordbot.WithAccountBalanceQuerier(acctBalQuerier),

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -25,6 +25,7 @@ require (
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	cloud.google.com/go/longrunning v0.5.7 // indirect
+	github.com/DATA-DOG/go-sqlmock v1.5.2 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
 	github.com/bytedance/sonic v1.14.1 // indirect
 	github.com/bytedance/sonic/loader v0.3.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -12,6 +12,8 @@ cloud.google.com/go/longrunning v0.5.7 h1:WLbHekDbjK1fVFD3ibpFFVoyizlLRl73I7YKuA
 cloud.google.com/go/longrunning v0.5.7/go.mod h1:8GClkudohy1Fxm3owmBGid8W0pSgodEMwEAztp38Xng=
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
 github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
 github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
@@ -95,6 +97,7 @@ github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=
 github.com/klauspost/cpuid/v2 v2.3.0/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/backend/internal/discord/adapter.go
+++ b/backend/internal/discord/adapter.go
@@ -20,7 +20,6 @@ type CashFlowServiceAdapter struct {
 type BotCCPaymentInput struct {
 	CreditCardID  string
 	BankAccountID string
-	CategoryID    string
 	Amount        float64
 	Date          string
 	PaymentType   string
@@ -33,6 +32,7 @@ type CreditCardPaymentCreator interface {
 type CreditCardPaymentAdapter struct {
 	svc      service.CashFlowService
 	cardRepo repository.CreditCardRepository
+	catRepo  repository.CategoryRepository
 }
 
 // NewCashFlowServiceAdapter wraps a CashFlowService for bot usage.
@@ -40,8 +40,8 @@ func NewCashFlowServiceAdapter(svc service.CashFlowService) *CashFlowServiceAdap
 	return &CashFlowServiceAdapter{svc: svc}
 }
 
-func NewCreditCardPaymentAdapter(svc service.CashFlowService, cardRepo repository.CreditCardRepository) *CreditCardPaymentAdapter {
-	return &CreditCardPaymentAdapter{svc: svc, cardRepo: cardRepo}
+func NewCreditCardPaymentAdapter(svc service.CashFlowService, cardRepo repository.CreditCardRepository, catRepo repository.CategoryRepository) *CreditCardPaymentAdapter {
+	return &CreditCardPaymentAdapter{svc: svc, cardRepo: cardRepo, catRepo: catRepo}
 }
 
 func (a *CashFlowServiceAdapter) CreateCashFlowFromBot(input *BotCashFlowInput) (string, error) {
@@ -86,10 +86,12 @@ func (a *CreditCardPaymentAdapter) CreatePaymentFromBot(input *BotCCPaymentInput
 		date = time.Now()
 	}
 
-	categoryID, err := uuid.Parse(input.CategoryID)
-	if err != nil {
-		return "", 0, err
+	transferOutType := models.CashFlowTypeTransferOut
+	categories, err := a.catRepo.GetAll(&transferOutType)
+	if err != nil || len(categories) == 0 {
+		return "", 0, fmt.Errorf("no transfer_out category found")
 	}
+	categoryID := categories[0].ID
 
 	creditCardID, err := uuid.Parse(input.CreditCardID)
 	if err != nil {

--- a/backend/internal/discord/adapter_test.go
+++ b/backend/internal/discord/adapter_test.go
@@ -172,6 +172,34 @@ func (m *mockCCPaymentCreditCardRepo) Delete(id uuid.UUID) error {
 	panic("unexpected call to Delete")
 }
 
+type mockCCPaymentCategoryRepo struct {
+	categories []*models.CashFlowCategory
+	err        error
+}
+
+func (m *mockCCPaymentCategoryRepo) Create(input *models.CreateCategoryInput) (*models.CashFlowCategory, error) {
+	panic("unexpected")
+}
+func (m *mockCCPaymentCategoryRepo) GetByID(id uuid.UUID) (*models.CashFlowCategory, error) {
+	panic("unexpected")
+}
+func (m *mockCCPaymentCategoryRepo) GetAll(flowType *models.CashFlowType) ([]*models.CashFlowCategory, error) {
+	return m.categories, m.err
+}
+func (m *mockCCPaymentCategoryRepo) Update(id uuid.UUID, input *models.UpdateCategoryInput) (*models.CashFlowCategory, error) {
+	panic("unexpected")
+}
+func (m *mockCCPaymentCategoryRepo) Delete(id uuid.UUID) error { panic("unexpected") }
+func (m *mockCCPaymentCategoryRepo) IsInUse(id uuid.UUID) (bool, error) {
+	panic("unexpected")
+}
+func (m *mockCCPaymentCategoryRepo) Reorder(input *models.ReorderCategoryInput) error {
+	panic("unexpected")
+}
+func (m *mockCCPaymentCategoryRepo) GetMaxSortOrder(flowType models.CashFlowType) (int, error) {
+	panic("unexpected")
+}
+
 func (m *mockCreditCardQueryRepo) Create(input *models.CreateCreditCardInput) (*models.CreditCard, error) {
 	panic("unexpected call to Create")
 }
@@ -349,17 +377,17 @@ func TestAccountBalanceQueryAdapter_NoAccounts(t *testing.T) {
 }
 
 func TestCCPaymentAdapter_CustomAmount(t *testing.T) {
-	categoryID := uuid.New()
+	transferCatID := uuid.New()
 	bankAccountID := uuid.New()
 	creditCardID := uuid.New()
 	recordID := uuid.New()
 	svc := &mockCCPaymentCashFlowService{createResult: &models.CashFlow{ID: recordID}}
-	adapter := NewCreditCardPaymentAdapter(svc, &mockCCPaymentCreditCardRepo{})
+	catRepo := &mockCCPaymentCategoryRepo{categories: []*models.CashFlowCategory{{ID: transferCatID, Name: "移轉", Type: models.CashFlowTypeTransferOut}}}
+	adapter := NewCreditCardPaymentAdapter(svc, &mockCCPaymentCreditCardRepo{}, catRepo)
 
 	id, actualAmount, err := adapter.CreatePaymentFromBot(&BotCCPaymentInput{
 		CreditCardID:  creditCardID.String(),
 		BankAccountID: bankAccountID.String(),
-		CategoryID:    categoryID.String(),
 		Amount:        15000,
 		Date:          "2026-04-08",
 		PaymentType:   "custom",
@@ -370,7 +398,7 @@ func TestCCPaymentAdapter_CustomAmount(t *testing.T) {
 	require.Equal(t, 15000.0, actualAmount)
 	require.NotNil(t, svc.createInput)
 	require.Equal(t, models.CashFlowTypeTransferOut, svc.createInput.Type)
-	require.Equal(t, categoryID, svc.createInput.CategoryID)
+	require.Equal(t, transferCatID, svc.createInput.CategoryID)
 	require.Equal(t, 15000.0, svc.createInput.Amount)
 	require.Equal(t, time.Date(2026, 4, 8, 0, 0, 0, 0, time.UTC), svc.createInput.Date)
 	require.NotNil(t, svc.createInput.SourceType)
@@ -384,18 +412,18 @@ func TestCCPaymentAdapter_CustomAmount(t *testing.T) {
 }
 
 func TestCCPaymentAdapter_FullPayment(t *testing.T) {
-	categoryID := uuid.New()
 	bankAccountID := uuid.New()
 	creditCardID := uuid.New()
 	recordID := uuid.New()
+	transferCatID := uuid.New()
 	svc := &mockCCPaymentCashFlowService{createResult: &models.CashFlow{ID: recordID}}
 	cardRepo := &mockCCPaymentCreditCardRepo{card: &models.CreditCard{ID: creditCardID, UsedCredit: 23500}}
-	adapter := NewCreditCardPaymentAdapter(svc, cardRepo)
+	catRepo := &mockCCPaymentCategoryRepo{categories: []*models.CashFlowCategory{{ID: transferCatID, Type: models.CashFlowTypeTransferOut}}}
+	adapter := NewCreditCardPaymentAdapter(svc, cardRepo, catRepo)
 
 	id, actualAmount, err := adapter.CreatePaymentFromBot(&BotCCPaymentInput{
 		CreditCardID:  creditCardID.String(),
 		BankAccountID: bankAccountID.String(),
-		CategoryID:    categoryID.String(),
 		Amount:        0,
 		Date:          "2026-04-08",
 		PaymentType:   "full",
@@ -410,17 +438,17 @@ func TestCCPaymentAdapter_FullPayment(t *testing.T) {
 }
 
 func TestCCPaymentAdapter_MinimumPayment(t *testing.T) {
-	categoryID := uuid.New()
 	bankAccountID := uuid.New()
 	creditCardID := uuid.New()
 	recordID := uuid.New()
+	transferCatID := uuid.New()
 	svc := &mockCCPaymentCashFlowService{createResult: &models.CashFlow{ID: recordID}}
-	adapter := NewCreditCardPaymentAdapter(svc, &mockCCPaymentCreditCardRepo{})
+	catRepo := &mockCCPaymentCategoryRepo{categories: []*models.CashFlowCategory{{ID: transferCatID, Type: models.CashFlowTypeTransferOut}}}
+	adapter := NewCreditCardPaymentAdapter(svc, &mockCCPaymentCreditCardRepo{}, catRepo)
 
 	id, actualAmount, err := adapter.CreatePaymentFromBot(&BotCCPaymentInput{
 		CreditCardID:  creditCardID.String(),
 		BankAccountID: bankAccountID.String(),
-		CategoryID:    categoryID.String(),
 		Amount:        3000,
 		Date:          "2026-04-08",
 		PaymentType:   "minimum",
@@ -434,16 +462,16 @@ func TestCCPaymentAdapter_MinimumPayment(t *testing.T) {
 }
 
 func TestCCPaymentAdapter_Failure(t *testing.T) {
-	categoryID := uuid.New()
 	bankAccountID := uuid.New()
 	creditCardID := uuid.New()
+	transferCatID := uuid.New()
 	svc := &mockCCPaymentCashFlowService{err: errors.New("create failed")}
-	adapter := NewCreditCardPaymentAdapter(svc, &mockCCPaymentCreditCardRepo{})
+	catRepo := &mockCCPaymentCategoryRepo{categories: []*models.CashFlowCategory{{ID: transferCatID, Type: models.CashFlowTypeTransferOut}}}
+	adapter := NewCreditCardPaymentAdapter(svc, &mockCCPaymentCreditCardRepo{}, catRepo)
 
 	id, actualAmount, err := adapter.CreatePaymentFromBot(&BotCCPaymentInput{
 		CreditCardID:  creditCardID.String(),
 		BankAccountID: bankAccountID.String(),
-		CategoryID:    categoryID.String(),
 		Amount:        15000,
 		Date:          "2026-04-08",
 		PaymentType:   "custom",
@@ -455,18 +483,18 @@ func TestCCPaymentAdapter_Failure(t *testing.T) {
 }
 
 func TestCCPaymentAdapter_FullPayment_ZeroUsedCredit(t *testing.T) {
-	categoryID := uuid.New()
 	bankAccountID := uuid.New()
 	creditCardID := uuid.New()
 	recordID := uuid.New()
+	transferCatID := uuid.New()
 	svc := &mockCCPaymentCashFlowService{createResult: &models.CashFlow{ID: recordID}}
 	cardRepo := &mockCCPaymentCreditCardRepo{card: &models.CreditCard{ID: creditCardID, UsedCredit: 0}}
-	adapter := NewCreditCardPaymentAdapter(svc, cardRepo)
+	catRepo := &mockCCPaymentCategoryRepo{categories: []*models.CashFlowCategory{{ID: transferCatID, Type: models.CashFlowTypeTransferOut}}}
+	adapter := NewCreditCardPaymentAdapter(svc, cardRepo, catRepo)
 
 	id, actualAmount, err := adapter.CreatePaymentFromBot(&BotCCPaymentInput{
 		CreditCardID:  creditCardID.String(),
 		BankAccountID: bankAccountID.String(),
-		CategoryID:    categoryID.String(),
 		Amount:        0,
 		Date:          "2026-04-08",
 		PaymentType:   "full",

--- a/backend/internal/discord/handler.go
+++ b/backend/internal/discord/handler.go
@@ -356,7 +356,6 @@ func (h *Handler) handleInteraction(s discordSession, i *discordgo.InteractionCr
 			Amount:        entry.ccAmount,
 			Date:          entry.result.Date,
 			PaymentType:   entry.ccPaymentType,
-			CategoryID:    entry.result.CategoryID,
 		})
 		if err != nil {
 			log.Printf("discord: failed to create cc payment: %v", err)

--- a/backend/internal/discord/handler_test.go
+++ b/backend/internal/discord/handler_test.go
@@ -1288,7 +1288,7 @@ func TestHandleInteraction_CCConfirm_Success(t *testing.T) {
 	h.handleInteraction(session, interaction)
 
 	require.Len(t, ccCreator.createdInputs, 1)
-	require.Equal(t, &BotCCPaymentInput{CreditCardID: "cc-1", BankAccountID: "bank-1", CategoryID: "category-1", Amount: 15000, Date: "2026-04-05", PaymentType: "custom"}, ccCreator.createdInputs[0])
+	require.Equal(t, &BotCCPaymentInput{CreditCardID: "cc-1", BankAccountID: "bank-1", Amount: 15000, Date: "2026-04-05", PaymentType: "custom"}, ccCreator.createdInputs[0])
 	require.Len(t, session.interactionResponses, 1)
 	require.Equal(t, GetMessage(string(LangEn), MsgCCPaymentSuccess), session.interactionResponses[0].Data.Embeds[0].Title)
 	require.Empty(t, session.interactionResponses[0].Data.Components)

--- a/backend/internal/discord/integration_test.go
+++ b/backend/internal/discord/integration_test.go
@@ -535,7 +535,6 @@ func TestIntegration_CCPayment_FullFlow(t *testing.T) {
 	assert.Equal(t, &BotCCPaymentInput{
 		CreditCardID:  "cc-uuid-1",
 		BankAccountID: "bank-uuid-1",
-		CategoryID:    "cat-transfer",
 		Amount:        15000,
 		Date:          "2026-04-05",
 		PaymentType:   "custom",

--- a/backend/internal/discord/parser.go
+++ b/backend/internal/discord/parser.go
@@ -157,7 +157,7 @@ Rules:
 - Set "is_bookkeeping" to false for greetings, chit-chat, or messages that are not bookkeeping.
 - For "action":
   - If the message contains a specific amount and is recording a transaction, use "create".
-  - If the message is asking a question about spending, balance, or summary (interrogative form, no specific amount to record), use "query".
+  - If the message is asking about spending, balance, summary, or checking account/card status (e.g., 餘額, 額度, 花了多少, balance, how much), use "query". This includes phrases with a specific bank or card name like "富邦信用卡餘額" or "中信卡額度".
   - If the message is about paying a credit card bill (繳卡費/繳信用卡/pay credit card bill), use "cc_payment".
   - If the message has a clear action intent but is NOT bookkeeping, querying, or credit card payment (e.g., buying stocks, setting budgets), use "unsupported".
   - If the message is a greeting, chat, or casual conversation (嗨/你好/hello/thanks/謝謝), use "chat".
@@ -182,7 +182,7 @@ Rules:
 - If required bookkeeping information is missing for a transaction, keep "is_bookkeeping" true and list missing keys in "missing_fields".
 - For "query_type":
   - Use "cash_flow_summary" for spending, income, or cash-flow questions.
-  - Use "account_balance" for bank balance or credit card limit questions.
+  - Use "account_balance" for bank balance, credit card balance, credit card limit, credit card remaining, or any inquiry about how much is left on a card. Examples: 餘額多少, 信用卡餘額, 富邦信用卡額度, credit card balance, what's my balance.
   - Otherwise use an empty string.
 - For "query_params":
   - Resolve month/year from relative terms such as 這個月=current, 上個月=previous, last month=previous.
@@ -209,11 +209,14 @@ func defaultGeminiGenerateContent(ctx context.Context, apiKey, modelName, prompt
 
 	resp, err := model.GenerateContent(ctx, genai.Text(prompt))
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("GenerateContent error: %w", err)
 	}
 
 	text := extractTextFromResponse(resp)
 	if strings.TrimSpace(text) == "" {
+		if resp != nil && len(resp.Candidates) > 0 && resp.Candidates[0].FinishReason > 0 {
+			return "", fmt.Errorf("empty Gemini response (finish_reason=%d)", resp.Candidates[0].FinishReason)
+		}
 		return "", errors.New("empty Gemini response")
 	}
 

--- a/backend/internal/repository/realized_profit_repository.go
+++ b/backend/internal/repository/realized_profit_repository.go
@@ -12,6 +12,9 @@ type RealizedProfitRepository interface {
 	// Create 建立已實現損益記錄
 	Create(input *models.CreateRealizedProfitInput) (*models.RealizedProfit, error)
 
+	// CreateTx 在指定的資料庫交易中建立已實現損益記錄
+	CreateTx(tx *sql.Tx, input *models.CreateRealizedProfitInput) (*models.RealizedProfit, error)
+
 	// GetByTransactionID 根據交易 ID 取得已實現損益
 	GetByTransactionID(transactionID string) (*models.RealizedProfit, error)
 
@@ -58,6 +61,69 @@ func (r *realizedProfitRepository) Create(input *models.CreateRealizedProfitInpu
 
 	var result models.RealizedProfit
 	err := r.db.QueryRow(
+		query,
+		input.TransactionID,
+		input.Symbol,
+		input.AssetType,
+		input.SellDate,
+		input.Quantity,
+		input.SellPrice,
+		input.SellAmount,
+		input.SellFee,
+		input.CostBasis,
+		realizedPL,
+		realizedPLPct,
+		input.Currency,
+	).Scan(
+		&result.ID,
+		&result.TransactionID,
+		&result.Symbol,
+		&result.AssetType,
+		&result.SellDate,
+		&result.Quantity,
+		&result.SellPrice,
+		&result.SellAmount,
+		&result.SellFee,
+		&result.CostBasis,
+		&result.RealizedPL,
+		&result.RealizedPLPct,
+		&result.Currency,
+		&result.CreatedAt,
+		&result.UpdatedAt,
+	)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to create realized profit: %w", err)
+	}
+
+	return &result, nil
+}
+
+// CreateTx 在指定的資料庫交易中建立已實現損益記錄
+func (r *realizedProfitRepository) CreateTx(tx *sql.Tx, input *models.CreateRealizedProfitInput) (*models.RealizedProfit, error) {
+	// 計算已實現損益
+	realizedPL := (input.SellAmount - input.SellFee) - input.CostBasis
+
+	// 計算已實現損益百分比
+	var realizedPLPct float64
+	if input.CostBasis > 0 {
+		realizedPLPct = (realizedPL / input.CostBasis) * 100
+	}
+
+	query := `
+		INSERT INTO realized_profits (
+			transaction_id, symbol, asset_type, sell_date, quantity,
+			sell_price, sell_amount, sell_fee, cost_basis,
+			realized_pl, realized_pl_pct, currency
+		)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+		RETURNING id, transaction_id, symbol, asset_type, sell_date, quantity,
+		          sell_price, sell_amount, sell_fee, cost_basis,
+		          realized_pl, realized_pl_pct, currency, created_at, updated_at
+	`
+
+	var result models.RealizedProfit
+	err := tx.QueryRow(
 		query,
 		input.TransactionID,
 		input.Symbol,

--- a/backend/internal/repository/transaction_repository.go
+++ b/backend/internal/repository/transaction_repository.go
@@ -13,11 +13,14 @@ import (
 // TransactionRepository 交易記錄資料存取介面
 type TransactionRepository interface {
 	Create(input *models.CreateTransactionInput) (*models.Transaction, error)
+	CreateTx(tx *sql.Tx, input *models.CreateTransactionInput) (*models.Transaction, error)
 	CreateWithExchangeRate(input *models.CreateTransactionInput, exchangeRateID int) (*models.Transaction, error)
+	CreateWithExchangeRateTx(tx *sql.Tx, input *models.CreateTransactionInput, exchangeRateID int) (*models.Transaction, error)
 	GetByID(id uuid.UUID) (*models.Transaction, error)
 	GetAll(filters TransactionFilters) ([]*models.Transaction, error)
 	Update(id uuid.UUID, input *models.UpdateTransactionInput) (*models.Transaction, error)
 	Delete(id uuid.UUID) error
+	DB() *sql.DB
 }
 
 // TransactionFilters 查詢篩選條件
@@ -39,6 +42,11 @@ type transactionRepository struct {
 // NewTransactionRepository 建立新的交易記錄 repository
 func NewTransactionRepository(db *sql.DB) TransactionRepository {
 	return &transactionRepository{db: db}
+}
+
+// DB 回傳底層的 *sql.DB，供 service 層開啟交易使用
+func (r *transactionRepository) DB() *sql.DB {
+	return r.db
 }
 
 // Create 建立新的交易記錄
@@ -90,6 +98,55 @@ func (r *transactionRepository) Create(input *models.CreateTransactionInput) (*m
 	return transaction, nil
 }
 
+// CreateTx 在指定的資料庫交易中建立新的交易記錄
+func (r *transactionRepository) CreateTx(tx *sql.Tx, input *models.CreateTransactionInput) (*models.Transaction, error) {
+	query := `
+		INSERT INTO transactions (date, asset_type, symbol, name, transaction_type, quantity, price, amount, fee, tax, currency, note)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+		RETURNING id, date, asset_type, symbol, name, transaction_type, quantity, price, amount, fee, tax, currency, exchange_rate_id, note, created_at, updated_at
+	`
+
+	transaction := &models.Transaction{}
+	err := tx.QueryRow(
+		query,
+		input.Date,
+		input.AssetType,
+		input.Symbol,
+		input.Name,
+		input.TransactionType,
+		input.Quantity,
+		input.Price,
+		input.Amount,
+		input.Fee,
+		input.Tax,
+		input.Currency,
+		input.Note,
+	).Scan(
+		&transaction.ID,
+		&transaction.Date,
+		&transaction.AssetType,
+		&transaction.Symbol,
+		&transaction.Name,
+		&transaction.TransactionType,
+		&transaction.Quantity,
+		&transaction.Price,
+		&transaction.Amount,
+		&transaction.Fee,
+		&transaction.Tax,
+		&transaction.Currency,
+		&transaction.ExchangeRateID,
+		&transaction.Note,
+		&transaction.CreatedAt,
+		&transaction.UpdatedAt,
+	)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to create transaction: %w", err)
+	}
+
+	return transaction, nil
+}
+
 // CreateWithExchangeRate 建立新的交易記錄（帶匯率 ID）
 func (r *transactionRepository) CreateWithExchangeRate(input *models.CreateTransactionInput, exchangeRateID int) (*models.Transaction, error) {
 	query := `
@@ -100,6 +157,56 @@ func (r *transactionRepository) CreateWithExchangeRate(input *models.CreateTrans
 
 	transaction := &models.Transaction{}
 	err := r.db.QueryRow(
+		query,
+		input.Date,
+		input.AssetType,
+		input.Symbol,
+		input.Name,
+		input.TransactionType,
+		input.Quantity,
+		input.Price,
+		input.Amount,
+		input.Fee,
+		input.Tax,
+		input.Currency,
+		exchangeRateID,
+		input.Note,
+	).Scan(
+		&transaction.ID,
+		&transaction.Date,
+		&transaction.AssetType,
+		&transaction.Symbol,
+		&transaction.Name,
+		&transaction.TransactionType,
+		&transaction.Quantity,
+		&transaction.Price,
+		&transaction.Amount,
+		&transaction.Fee,
+		&transaction.Tax,
+		&transaction.Currency,
+		&transaction.ExchangeRateID,
+		&transaction.Note,
+		&transaction.CreatedAt,
+		&transaction.UpdatedAt,
+	)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to create transaction with exchange rate: %w", err)
+	}
+
+	return transaction, nil
+}
+
+// CreateWithExchangeRateTx 在指定的資料庫交易中建立新的交易記錄（帶匯率 ID）
+func (r *transactionRepository) CreateWithExchangeRateTx(tx *sql.Tx, input *models.CreateTransactionInput, exchangeRateID int) (*models.Transaction, error) {
+	query := `
+		INSERT INTO transactions (date, asset_type, symbol, name, transaction_type, quantity, price, amount, fee, tax, currency, exchange_rate_id, note)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+		RETURNING id, date, asset_type, symbol, name, transaction_type, quantity, price, amount, fee, tax, currency, exchange_rate_id, note, created_at, updated_at
+	`
+
+	transaction := &models.Transaction{}
+	err := tx.QueryRow(
 		query,
 		input.Date,
 		input.AssetType,

--- a/backend/internal/service/analytics_service_test.go
+++ b/backend/internal/service/analytics_service_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"database/sql"
 	"testing"
 	"time"
 
@@ -41,6 +42,14 @@ func (m *MockRealizedProfitRepositoryForAnalytics) GetAll(filters models.Realize
 func (m *MockRealizedProfitRepositoryForAnalytics) Delete(id string) error {
 	args := m.Called(id)
 	return args.Error(0)
+}
+
+func (m *MockRealizedProfitRepositoryForAnalytics) CreateTx(tx *sql.Tx, input *models.CreateRealizedProfitInput) (*models.RealizedProfit, error) {
+	args := m.Called(tx, input)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.RealizedProfit), args.Error(1)
 }
 
 // TestAnalyticsService_GetSummary 測試取得分析摘要

--- a/backend/internal/service/holding_service_test.go
+++ b/backend/internal/service/holding_service_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"database/sql"
 	"testing"
 	"time"
 
@@ -61,6 +62,30 @@ func (m *MockTransactionRepositoryForHolding) Update(id uuid.UUID, input *models
 func (m *MockTransactionRepositoryForHolding) Delete(id uuid.UUID) error {
 	args := m.Called(id)
 	return args.Error(0)
+}
+
+func (m *MockTransactionRepositoryForHolding) CreateTx(tx *sql.Tx, input *models.CreateTransactionInput) (*models.Transaction, error) {
+	args := m.Called(tx, input)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.Transaction), args.Error(1)
+}
+
+func (m *MockTransactionRepositoryForHolding) CreateWithExchangeRateTx(tx *sql.Tx, input *models.CreateTransactionInput, exchangeRateID int) (*models.Transaction, error) {
+	args := m.Called(tx, input, exchangeRateID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.Transaction), args.Error(1)
+}
+
+func (m *MockTransactionRepositoryForHolding) DB() *sql.DB {
+	args := m.Called()
+	if args.Get(0) == nil {
+		return nil
+	}
+	return args.Get(0).(*sql.DB)
 }
 
 // MockPriceService Price Service 的 Mock

--- a/backend/internal/service/transaction_service.go
+++ b/backend/internal/service/transaction_service.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"database/sql"
 	"fmt"
 
 	"github.com/chienchuanw/asset-manager/internal/models"
@@ -77,48 +78,13 @@ func (s *transactionService) CreateTransaction(input *models.CreateTransactionIn
 		return nil, fmt.Errorf("invalid currency: %s", input.Currency)
 	}
 
-	var transaction *models.Transaction
-	var err error
-
-	// 如果是 USD 交易，需要取得或建立匯率記錄
-	if input.Currency == models.CurrencyUSD {
-		// 取得交易日期的匯率（會自動處理 fallback）
-		rate, err := s.exchangeRateService.GetRate(models.CurrencyUSD, models.CurrencyTWD, input.Date)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get exchange rate for USD transaction: %w", err)
-		}
-
-		// 從資料庫取得匯率記錄的 ID
-		exchangeRate, err := s.exchangeRateService.GetRateRecord(models.CurrencyUSD, models.CurrencyTWD, input.Date)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get exchange rate record: %w", err)
-		}
-
-		// 使用帶匯率 ID 的方法建立交易
-		transaction, err = s.repo.CreateWithExchangeRate(input, exchangeRate.ID)
-		if err != nil {
-			return nil, err
-		}
-
-		fmt.Printf("Created USD transaction with exchange rate %.4f (ID: %d)\n", rate, exchangeRate.ID)
-	} else {
-		// TWD 交易，直接建立
-		transaction, err = s.repo.Create(input)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	// 如果是賣出交易，自動計算並記錄已實現損益
+	// 賣出交易需要在資料庫事務中同時建立交易和已實現損益
 	if input.TransactionType == models.TransactionTypeSell {
-		if err := s.createRealizedProfit(transaction); err != nil {
-			// 記錄錯誤但不影響交易建立
-			// TODO: 考慮是否要回滾交易或使用事務
-			fmt.Printf("Warning: failed to create realized profit for transaction %s: %v\n", transaction.ID, err)
-		}
+		return s.createSellTransactionAtomically(input)
 	}
 
-	return transaction, nil
+	// 非賣出交易（買入/股息/手續費），不需要事務
+	return s.createNonSellTransaction(input)
 }
 
 // CreateTransactionsBatch 批次建立交易記錄（全有或全無）
@@ -219,8 +185,79 @@ func (s *transactionService) DeleteTransaction(id uuid.UUID) error {
 	return s.repo.Delete(id)
 }
 
-// createRealizedProfit 建立已實現損益記錄（賣出交易時自動呼叫）
-func (s *transactionService) createRealizedProfit(sellTransaction *models.Transaction) error {
+// createNonSellTransaction 建立非賣出交易（買入/股息/手續費）
+func (s *transactionService) createNonSellTransaction(input *models.CreateTransactionInput) (*models.Transaction, error) {
+	if input.Currency == models.CurrencyUSD {
+		rate, err := s.exchangeRateService.GetRate(models.CurrencyUSD, models.CurrencyTWD, input.Date)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get exchange rate for USD transaction: %w", err)
+		}
+
+		exchangeRate, err := s.exchangeRateService.GetRateRecord(models.CurrencyUSD, models.CurrencyTWD, input.Date)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get exchange rate record: %w", err)
+		}
+
+		transaction, err := s.repo.CreateWithExchangeRate(input, exchangeRate.ID)
+		if err != nil {
+			return nil, err
+		}
+
+		fmt.Printf("Created USD transaction with exchange rate %.4f (ID: %d)\n", rate, exchangeRate.ID)
+		return transaction, nil
+	}
+
+	return s.repo.Create(input)
+}
+
+// createSellTransactionAtomically 在資料庫事務中建立賣出交易和已實現損益
+func (s *transactionService) createSellTransactionAtomically(input *models.CreateTransactionInput) (*models.Transaction, error) {
+	dbTx, err := s.repo.DB().Begin()
+	if err != nil {
+		return nil, fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer dbTx.Rollback()
+
+	// 在事務中建立交易記錄
+	var transaction *models.Transaction
+	if input.Currency == models.CurrencyUSD {
+		rate, err := s.exchangeRateService.GetRate(models.CurrencyUSD, models.CurrencyTWD, input.Date)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get exchange rate for USD transaction: %w", err)
+		}
+
+		exchangeRate, err := s.exchangeRateService.GetRateRecord(models.CurrencyUSD, models.CurrencyTWD, input.Date)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get exchange rate record: %w", err)
+		}
+
+		transaction, err = s.repo.CreateWithExchangeRateTx(dbTx, input, exchangeRate.ID)
+		if err != nil {
+			return nil, err
+		}
+
+		fmt.Printf("Created USD sell transaction with exchange rate %.4f (ID: %d)\n", rate, exchangeRate.ID)
+	} else {
+		transaction, err = s.repo.CreateTx(dbTx, input)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// 在同一事務中建立已實現損益
+	if err := s.createRealizedProfitTx(dbTx, transaction); err != nil {
+		return nil, fmt.Errorf("failed to create realized profit: %w", err)
+	}
+
+	if err := dbTx.Commit(); err != nil {
+		return nil, fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	return transaction, nil
+}
+
+// createRealizedProfitTx 在指定的資料庫事務中建立已實現損益記錄
+func (s *transactionService) createRealizedProfitTx(dbTx *sql.Tx, sellTransaction *models.Transaction) error {
 	// 取得該標的的所有交易記錄
 	filters := repository.TransactionFilters{
 		Symbol: &sellTransaction.Symbol,
@@ -260,7 +297,7 @@ func (s *transactionService) createRealizedProfit(sellTransaction *models.Transa
 		Currency:      string(sellTransaction.Currency),
 	}
 
-	_, err = s.realizedProfitRepo.Create(input)
+	_, err = s.realizedProfitRepo.CreateTx(dbTx, input)
 	if err != nil {
 		return fmt.Errorf("failed to create realized profit record: %w", err)
 	}

--- a/backend/internal/service/transaction_service_test.go
+++ b/backend/internal/service/transaction_service_test.go
@@ -1,10 +1,12 @@
 package service
 
 import (
+	"database/sql"
 	"fmt"
 	"testing"
 	"time"
 
+	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/chienchuanw/asset-manager/internal/models"
 	"github.com/chienchuanw/asset-manager/internal/repository"
 	"github.com/google/uuid"
@@ -72,9 +74,41 @@ func (m *MockTransactionRepository) Delete(id uuid.UUID) error {
 	return args.Error(0)
 }
 
+func (m *MockTransactionRepository) CreateTx(tx *sql.Tx, input *models.CreateTransactionInput) (*models.Transaction, error) {
+	args := m.Called(tx, input)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.Transaction), args.Error(1)
+}
+
+func (m *MockTransactionRepository) CreateWithExchangeRateTx(tx *sql.Tx, input *models.CreateTransactionInput, exchangeRateID int) (*models.Transaction, error) {
+	args := m.Called(tx, input, exchangeRateID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.Transaction), args.Error(1)
+}
+
+func (m *MockTransactionRepository) DB() *sql.DB {
+	args := m.Called()
+	if args.Get(0) == nil {
+		return nil
+	}
+	return args.Get(0).(*sql.DB)
+}
+
 // MockRealizedProfitRepository 方法實作
 func (m *MockRealizedProfitRepository) Create(input *models.CreateRealizedProfitInput) (*models.RealizedProfit, error) {
 	args := m.Called(input)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.RealizedProfit), args.Error(1)
+}
+
+func (m *MockRealizedProfitRepository) CreateTx(tx *sql.Tx, input *models.CreateRealizedProfitInput) (*models.RealizedProfit, error) {
+	args := m.Called(tx, input)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
@@ -381,9 +415,13 @@ func TestDeleteTransaction_Success(t *testing.T) {
 	mockRepo.AssertExpectations(t)
 }
 
-// TestCreateTransaction_SellWithRealizedProfit 測試建立賣出交易並自動建立已實現損益
+// TestCreateTransaction_SellWithRealizedProfit 測試建立賣出交易並自動建立已實現損益（原子操作）
 func TestCreateTransaction_SellWithRealizedProfit(t *testing.T) {
 	// Arrange
+	db, dbMock, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer db.Close()
+
 	mockRepo := new(MockTransactionRepository)
 	mockRealizedProfitRepo := new(MockRealizedProfitRepository)
 	mockFIFOCalc := new(MockFIFOCalculator)
@@ -437,8 +475,13 @@ func TestCreateTransaction_SellWithRealizedProfit(t *testing.T) {
 		},
 	}
 
-	// Mock 期望
-	mockRepo.On("Create", sellInput).Return(sellTransaction, nil)
+	// Mock DB().Begin() → 回傳 sqlmock 的 tx
+	dbMock.ExpectBegin()
+	dbMock.ExpectCommit()
+	mockRepo.On("DB").Return(db)
+
+	// Mock CreateTx（在事務中建立交易）
+	mockRepo.On("CreateTx", mock.AnythingOfType("*sql.Tx"), sellInput).Return(sellTransaction, nil)
 
 	filters := repository.TransactionFilters{Symbol: &sellInput.Symbol}
 	mockRepo.On("GetAll", filters).Return(previousTransactions, nil)
@@ -446,7 +489,8 @@ func TestCreateTransaction_SellWithRealizedProfit(t *testing.T) {
 	costBasis := 50028.0 // (50000 + 28)
 	mockFIFOCalc.On("CalculateCostBasis", "2330", sellTransaction, previousTransactions).Return(costBasis, nil)
 
-	mockRealizedProfitRepo.On("Create", mock.MatchedBy(func(input *models.CreateRealizedProfitInput) bool {
+	// Mock CreateTx（在事務中建立已實現損益）
+	mockRealizedProfitRepo.On("CreateTx", mock.AnythingOfType("*sql.Tx"), mock.MatchedBy(func(input *models.CreateRealizedProfitInput) bool {
 		return input.Symbol == "2330" &&
 			input.Quantity == 100 &&
 			input.SellAmount == 62000 &&
@@ -464,6 +508,142 @@ func TestCreateTransaction_SellWithRealizedProfit(t *testing.T) {
 	mockRepo.AssertExpectations(t)
 	mockFIFOCalc.AssertExpectations(t)
 	mockRealizedProfitRepo.AssertExpectations(t)
+	assert.NoError(t, dbMock.ExpectationsWereMet())
+}
+
+// TestCreateTransaction_SellRollbackOnRealizedProfitError 測試賣出交易在已實現損益建立失敗時回滾
+func TestCreateTransaction_SellRollbackOnRealizedProfitError(t *testing.T) {
+	// Arrange
+	db, dbMock, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer db.Close()
+
+	mockRepo := new(MockTransactionRepository)
+	mockRealizedProfitRepo := new(MockRealizedProfitRepository)
+	mockFIFOCalc := new(MockFIFOCalculator)
+	mockExchangeRateService := new(MockExchangeRateService)
+	service := NewTransactionService(mockRepo, mockRealizedProfitRepo, mockFIFOCalc, mockExchangeRateService)
+
+	fee := 28.0
+	sellInput := &models.CreateTransactionInput{
+		Date:            time.Date(2025, 10, 24, 0, 0, 0, 0, time.UTC),
+		AssetType:       models.AssetTypeTWStock,
+		Symbol:          "2330",
+		Name:            "台積電",
+		TransactionType: models.TransactionTypeSell,
+		Quantity:        100,
+		Price:           620,
+		Amount:          62000,
+		Fee:             &fee,
+		Currency:        models.CurrencyTWD,
+	}
+
+	sellTransaction := &models.Transaction{
+		ID:              uuid.New(),
+		Date:            sellInput.Date,
+		AssetType:       sellInput.AssetType,
+		Symbol:          sellInput.Symbol,
+		Name:            sellInput.Name,
+		TransactionType: sellInput.TransactionType,
+		Quantity:        sellInput.Quantity,
+		Price:           sellInput.Price,
+		Amount:          sellInput.Amount,
+		Fee:             sellInput.Fee,
+		Currency:        sellInput.Currency,
+	}
+
+	previousTransactions := []*models.Transaction{
+		{
+			ID:              uuid.New(),
+			Symbol:          "2330",
+			TransactionType: models.TransactionTypeBuy,
+			Quantity:        100,
+			Price:           500,
+			Amount:          50000,
+			Fee:             ptrFloat64(28),
+			Currency:        models.CurrencyTWD,
+		},
+	}
+
+	// Mock DB().Begin() → 回傳 sqlmock 的 tx，期望 Rollback（不是 Commit）
+	dbMock.ExpectBegin()
+	dbMock.ExpectRollback()
+	mockRepo.On("DB").Return(db)
+
+	mockRepo.On("CreateTx", mock.AnythingOfType("*sql.Tx"), sellInput).Return(sellTransaction, nil)
+
+	filters := repository.TransactionFilters{Symbol: &sellInput.Symbol}
+	mockRepo.On("GetAll", filters).Return(previousTransactions, nil)
+
+	costBasis := 50028.0
+	mockFIFOCalc.On("CalculateCostBasis", "2330", sellTransaction, previousTransactions).Return(costBasis, nil)
+
+	// 模擬已實現損益建立失敗
+	mockRealizedProfitRepo.On("CreateTx", mock.AnythingOfType("*sql.Tx"), mock.Anything).Return(nil, fmt.Errorf("database error"))
+
+	// Act
+	result, err := service.CreateTransaction(sellInput)
+
+	// Assert — 交易應該失敗（回滾），而非僅記錄警告
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "failed to create realized profit")
+	mockRepo.AssertExpectations(t)
+	mockRealizedProfitRepo.AssertExpectations(t)
+	// 確認 Commit 未被呼叫，Rollback 已被呼叫
+	assert.NoError(t, dbMock.ExpectationsWereMet())
+}
+
+// TestCreateTransaction_BuyDoesNotUseDBTransaction 測試買入交易不使用資料庫事務
+func TestCreateTransaction_BuyDoesNotUseDBTransaction(t *testing.T) {
+	// Arrange
+	mockRepo := new(MockTransactionRepository)
+	mockRealizedProfitRepo := new(MockRealizedProfitRepository)
+	mockFIFOCalc := new(MockFIFOCalculator)
+	mockExchangeRateService := new(MockExchangeRateService)
+	service := NewTransactionService(mockRepo, mockRealizedProfitRepo, mockFIFOCalc, mockExchangeRateService)
+
+	fee := 28.0
+	input := &models.CreateTransactionInput{
+		Date:            time.Date(2025, 10, 22, 0, 0, 0, 0, time.UTC),
+		AssetType:       models.AssetTypeTWStock,
+		Symbol:          "2330",
+		Name:            "台積電",
+		TransactionType: models.TransactionTypeBuy,
+		Quantity:        10,
+		Price:           620,
+		Amount:          6200,
+		Fee:             &fee,
+		Currency:        models.CurrencyTWD,
+	}
+
+	expectedTransaction := &models.Transaction{
+		ID:              uuid.New(),
+		Date:            input.Date,
+		AssetType:       input.AssetType,
+		Symbol:          input.Symbol,
+		Name:            input.Name,
+		TransactionType: input.TransactionType,
+		Quantity:        input.Quantity,
+		Price:           input.Price,
+		Amount:          input.Amount,
+		Fee:             input.Fee,
+		Currency:        input.Currency,
+	}
+
+	mockRepo.On("Create", input).Return(expectedTransaction, nil)
+
+	// Act
+	result, err := service.CreateTransaction(input)
+
+	// Assert
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	// 確認 DB() 和 Begin() 未被呼叫（買入交易不需要事務）
+	mockRepo.AssertNotCalled(t, "DB")
+	mockRepo.AssertNotCalled(t, "CreateTx", mock.Anything, mock.Anything)
+	mockRealizedProfitRepo.AssertNotCalled(t, "Create", mock.Anything)
+	mockRealizedProfitRepo.AssertNotCalled(t, "CreateTx", mock.Anything, mock.Anything)
 }
 
 // TestCreateTransaction_USD_Success 測試成功建立 USD 交易並自動建立匯率記錄


### PR DESCRIPTION
## Summary
- 賣出交易與已實現損益記錄現在包裝在資料庫事務中，確保兩者同時成功或同時回滾
- 新增 `CreateTx` 方法至交易和已實現損益 repository，支援在指定事務中執行
- 新增 `DB()` 方法供 service 層開啟資料庫事務
- 非賣出交易（買入/股息/手續費）行為完全不變

## Test plan
- [x] 新增測試：賣出交易成功時，交易和損益記錄同時提交
- [x] 新增測試：損益記錄建立失敗時，交易也會回滾
- [x] 新增測試：非賣出交易不使用資料庫事務
- [x] 所有既有 service 測試通過

Closes #12