### PR TITLE
fix: Discord bot pending store 新增 TTL 自動清除機制 (#13)

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -330,7 +330,7 @@ func startDiscordBot(cashFlowSvc service.CashFlowService, categoryRepo repositor
 	acctLoader := discordbot.NewAccountRepoAdapter(bankAccountRepo, creditCardRepo)
 	cfQuerier := discordbot.NewCashFlowQueryAdapter(cashFlowSvc)
 	acctBalQuerier := discordbot.NewAccountBalanceQueryAdapter(bankAccountRepo, creditCardRepo)
-	ccPaymentAdapter := discordbot.NewCreditCardPaymentAdapter(cashFlowSvc, creditCardRepo)
+	ccPaymentAdapter := discordbot.NewCreditCardPaymentAdapter(cashFlowSvc, creditCardRepo, categoryRepo)
 	handler := discordbot.NewHandler(parser, creator, catLoader, acctLoader, cfg.Lang,
 		discordbot.WithCashFlowQuerier(cfQuerier),
 		discordbot.WithAccountBalanceQuerier(acctBalQuerier),

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -46,6 +46,10 @@ func main() {
 	}
 	defer database.Close()
 
+	// 建立可取消的 context，供 Discord bot 清理 goroutine 使用
+	botCtx, botCancel := context.WithCancel(context.Background())
+	defer botCancel()
+
 	// 初始化 Repository
 	transactionRepo := repository.NewTransactionRepository(database)
 	exchangeRateRepo := repository.NewExchangeRateRepository(database)
@@ -176,7 +180,7 @@ func main() {
 
 		// 建立 router 並啟動（簡化版，不啟動排程器）
 		log.Println("Warning: Scheduler is disabled (Redis not available)")
-		bot := startDiscordBot(cashFlowService, categoryRepo, bankAccountRepo, creditCardRepo)
+		bot := startDiscordBot(botCtx, cashFlowService, categoryRepo, bankAccountRepo, creditCardRepo)
 		startServer(authHandler, transactionHandler, holdingHandler, analyticsHandler, unrealizedAnalyticsHandler, allocationHandler, performanceTrendHandler, settingsHandler, assetSnapshotHandler, discordHandler, schedulerHandler, rebalanceHandler, cashFlowHandler, categoryHandler, subscriptionHandler, installmentHandler, billingHandler, bankAccountHandler, creditCardHandler, creditCardGroupHandler, exchangeRateHandler, nil, bot)
 		return
 	}
@@ -298,7 +302,7 @@ func main() {
 	schedulerHandler := api.NewSchedulerHandler(schedulerManager)
 
 	// 啟動伺服器（會在內部處理 graceful shutdown）
-	bot := startDiscordBot(cashFlowService, categoryRepo, bankAccountRepo, creditCardRepo)
+	bot := startDiscordBot(botCtx, cashFlowService, categoryRepo, bankAccountRepo, creditCardRepo)
 	startServer(authHandler, transactionHandler, holdingHandler, analyticsHandler, unrealizedAnalyticsHandler, allocationHandler, performanceTrendHandler, settingsHandler, assetSnapshotHandler, discordHandler, schedulerHandler, rebalanceHandler, cashFlowHandler, categoryHandler, subscriptionHandler, installmentHandler, billingHandler, bankAccountHandler, creditCardHandler, creditCardGroupHandler, exchangeRateHandler, schedulerManager, bot)
 }
 
@@ -311,7 +315,7 @@ func getEnvOrDefault(key, defaultValue string) string {
 	return value
 }
 
-func startDiscordBot(cashFlowSvc service.CashFlowService, categoryRepo repository.CategoryRepository, bankAccountRepo repository.BankAccountRepository, creditCardRepo repository.CreditCardRepository) *discordbot.Bot {
+func startDiscordBot(ctx context.Context, cashFlowSvc service.CashFlowService, categoryRepo repository.CategoryRepository, bankAccountRepo repository.BankAccountRepository, creditCardRepo repository.CreditCardRepository) *discordbot.Bot {
 	cfg := discordbot.LoadConfig()
 	if !cfg.Enabled {
 		log.Println("Discord bot disabled")
@@ -331,7 +335,7 @@ func startDiscordBot(cashFlowSvc service.CashFlowService, categoryRepo repositor
 	cfQuerier := discordbot.NewCashFlowQueryAdapter(cashFlowSvc)
 	acctBalQuerier := discordbot.NewAccountBalanceQueryAdapter(bankAccountRepo, creditCardRepo)
 	ccPaymentAdapter := discordbot.NewCreditCardPaymentAdapter(cashFlowSvc, creditCardRepo, categoryRepo)
-	handler := discordbot.NewHandler(parser, creator, catLoader, acctLoader, cfg.Lang,
+	handler := discordbot.NewHandler(ctx, parser, creator, catLoader, acctLoader, cfg.Lang,
 		discordbot.WithCashFlowQuerier(cfQuerier),
 		discordbot.WithAccountBalanceQuerier(acctBalQuerier),
 		discordbot.WithCCPaymentCreator(ccPaymentAdapter),

--- a/backend/internal/discord/adapter.go
+++ b/backend/internal/discord/adapter.go
@@ -20,7 +20,6 @@ type CashFlowServiceAdapter struct {
 type BotCCPaymentInput struct {
 	CreditCardID  string
 	BankAccountID string
-	CategoryID    string
 	Amount        float64
 	Date          string
 	PaymentType   string
@@ -33,6 +32,7 @@ type CreditCardPaymentCreator interface {
 type CreditCardPaymentAdapter struct {
 	svc      service.CashFlowService
 	cardRepo repository.CreditCardRepository
+	catRepo  repository.CategoryRepository
 }
 
 // NewCashFlowServiceAdapter wraps a CashFlowService for bot usage.
@@ -40,8 +40,8 @@ func NewCashFlowServiceAdapter(svc service.CashFlowService) *CashFlowServiceAdap
 	return &CashFlowServiceAdapter{svc: svc}
 }
 
-func NewCreditCardPaymentAdapter(svc service.CashFlowService, cardRepo repository.CreditCardRepository) *CreditCardPaymentAdapter {
-	return &CreditCardPaymentAdapter{svc: svc, cardRepo: cardRepo}
+func NewCreditCardPaymentAdapter(svc service.CashFlowService, cardRepo repository.CreditCardRepository, catRepo repository.CategoryRepository) *CreditCardPaymentAdapter {
+	return &CreditCardPaymentAdapter{svc: svc, cardRepo: cardRepo, catRepo: catRepo}
 }
 
 func (a *CashFlowServiceAdapter) CreateCashFlowFromBot(input *BotCashFlowInput) (string, error) {
@@ -86,10 +86,12 @@ func (a *CreditCardPaymentAdapter) CreatePaymentFromBot(input *BotCCPaymentInput
 		date = time.Now()
 	}
 
-	categoryID, err := uuid.Parse(input.CategoryID)
-	if err != nil {
-		return "", 0, err
+	transferOutType := models.CashFlowTypeTransferOut
+	categories, err := a.catRepo.GetAll(&transferOutType)
+	if err != nil || len(categories) == 0 {
+		return "", 0, fmt.Errorf("no transfer_out category found")
 	}
+	categoryID := categories[0].ID
 
 	creditCardID, err := uuid.Parse(input.CreditCardID)
 	if err != nil {

--- a/backend/internal/discord/adapter_test.go
+++ b/backend/internal/discord/adapter_test.go
@@ -172,6 +172,34 @@ func (m *mockCCPaymentCreditCardRepo) Delete(id uuid.UUID) error {
 	panic("unexpected call to Delete")
 }
 
+type mockCCPaymentCategoryRepo struct {
+	categories []*models.CashFlowCategory
+	err        error
+}
+
+func (m *mockCCPaymentCategoryRepo) Create(input *models.CreateCategoryInput) (*models.CashFlowCategory, error) {
+	panic("unexpected")
+}
+func (m *mockCCPaymentCategoryRepo) GetByID(id uuid.UUID) (*models.CashFlowCategory, error) {
+	panic("unexpected")
+}
+func (m *mockCCPaymentCategoryRepo) GetAll(flowType *models.CashFlowType) ([]*models.CashFlowCategory, error) {
+	return m.categories, m.err
+}
+func (m *mockCCPaymentCategoryRepo) Update(id uuid.UUID, input *models.UpdateCategoryInput) (*models.CashFlowCategory, error) {
+	panic("unexpected")
+}
+func (m *mockCCPaymentCategoryRepo) Delete(id uuid.UUID) error { panic("unexpected") }
+func (m *mockCCPaymentCategoryRepo) IsInUse(id uuid.UUID) (bool, error) {
+	panic("unexpected")
+}
+func (m *mockCCPaymentCategoryRepo) Reorder(input *models.ReorderCategoryInput) error {
+	panic("unexpected")
+}
+func (m *mockCCPaymentCategoryRepo) GetMaxSortOrder(flowType models.CashFlowType) (int, error) {
+	panic("unexpected")
+}
+
 func (m *mockCreditCardQueryRepo) Create(input *models.CreateCreditCardInput) (*models.CreditCard, error) {
 	panic("unexpected call to Create")
 }
@@ -349,17 +377,17 @@ func TestAccountBalanceQueryAdapter_NoAccounts(t *testing.T) {
 }
 
 func TestCCPaymentAdapter_CustomAmount(t *testing.T) {
-	categoryID := uuid.New()
+	transferCatID := uuid.New()
 	bankAccountID := uuid.New()
 	creditCardID := uuid.New()
 	recordID := uuid.New()
 	svc := &mockCCPaymentCashFlowService{createResult: &models.CashFlow{ID: recordID}}
-	adapter := NewCreditCardPaymentAdapter(svc, &mockCCPaymentCreditCardRepo{})
+	catRepo := &mockCCPaymentCategoryRepo{categories: []*models.CashFlowCategory{{ID: transferCatID, Name: "移轉", Type: models.CashFlowTypeTransferOut}}}
+	adapter := NewCreditCardPaymentAdapter(svc, &mockCCPaymentCreditCardRepo{}, catRepo)
 
 	id, actualAmount, err := adapter.CreatePaymentFromBot(&BotCCPaymentInput{
 		CreditCardID:  creditCardID.String(),
 		BankAccountID: bankAccountID.String(),
-		CategoryID:    categoryID.String(),
 		Amount:        15000,
 		Date:          "2026-04-08",
 		PaymentType:   "custom",
@@ -370,7 +398,7 @@ func TestCCPaymentAdapter_CustomAmount(t *testing.T) {
 	require.Equal(t, 15000.0, actualAmount)
 	require.NotNil(t, svc.createInput)
 	require.Equal(t, models.CashFlowTypeTransferOut, svc.createInput.Type)
-	require.Equal(t, categoryID, svc.createInput.CategoryID)
+	require.Equal(t, transferCatID, svc.createInput.CategoryID)
 	require.Equal(t, 15000.0, svc.createInput.Amount)
 	require.Equal(t, time.Date(2026, 4, 8, 0, 0, 0, 0, time.UTC), svc.createInput.Date)
 	require.NotNil(t, svc.createInput.SourceType)
@@ -384,18 +412,18 @@ func TestCCPaymentAdapter_CustomAmount(t *testing.T) {
 }
 
 func TestCCPaymentAdapter_FullPayment(t *testing.T) {
-	categoryID := uuid.New()
 	bankAccountID := uuid.New()
 	creditCardID := uuid.New()
 	recordID := uuid.New()
+	transferCatID := uuid.New()
 	svc := &mockCCPaymentCashFlowService{createResult: &models.CashFlow{ID: recordID}}
 	cardRepo := &mockCCPaymentCreditCardRepo{card: &models.CreditCard{ID: creditCardID, UsedCredit: 23500}}
-	adapter := NewCreditCardPaymentAdapter(svc, cardRepo)
+	catRepo := &mockCCPaymentCategoryRepo{categories: []*models.CashFlowCategory{{ID: transferCatID, Type: models.CashFlowTypeTransferOut}}}
+	adapter := NewCreditCardPaymentAdapter(svc, cardRepo, catRepo)
 
 	id, actualAmount, err := adapter.CreatePaymentFromBot(&BotCCPaymentInput{
 		CreditCardID:  creditCardID.String(),
 		BankAccountID: bankAccountID.String(),
-		CategoryID:    categoryID.String(),
 		Amount:        0,
 		Date:          "2026-04-08",
 		PaymentType:   "full",
@@ -410,17 +438,17 @@ func TestCCPaymentAdapter_FullPayment(t *testing.T) {
 }
 
 func TestCCPaymentAdapter_MinimumPayment(t *testing.T) {
-	categoryID := uuid.New()
 	bankAccountID := uuid.New()
 	creditCardID := uuid.New()
 	recordID := uuid.New()
+	transferCatID := uuid.New()
 	svc := &mockCCPaymentCashFlowService{createResult: &models.CashFlow{ID: recordID}}
-	adapter := NewCreditCardPaymentAdapter(svc, &mockCCPaymentCreditCardRepo{})
+	catRepo := &mockCCPaymentCategoryRepo{categories: []*models.CashFlowCategory{{ID: transferCatID, Type: models.CashFlowTypeTransferOut}}}
+	adapter := NewCreditCardPaymentAdapter(svc, &mockCCPaymentCreditCardRepo{}, catRepo)
 
 	id, actualAmount, err := adapter.CreatePaymentFromBot(&BotCCPaymentInput{
 		CreditCardID:  creditCardID.String(),
 		BankAccountID: bankAccountID.String(),
-		CategoryID:    categoryID.String(),
 		Amount:        3000,
 		Date:          "2026-04-08",
 		PaymentType:   "minimum",
@@ -434,16 +462,16 @@ func TestCCPaymentAdapter_MinimumPayment(t *testing.T) {
 }
 
 func TestCCPaymentAdapter_Failure(t *testing.T) {
-	categoryID := uuid.New()
 	bankAccountID := uuid.New()
 	creditCardID := uuid.New()
+	transferCatID := uuid.New()
 	svc := &mockCCPaymentCashFlowService{err: errors.New("create failed")}
-	adapter := NewCreditCardPaymentAdapter(svc, &mockCCPaymentCreditCardRepo{})
+	catRepo := &mockCCPaymentCategoryRepo{categories: []*models.CashFlowCategory{{ID: transferCatID, Type: models.CashFlowTypeTransferOut}}}
+	adapter := NewCreditCardPaymentAdapter(svc, &mockCCPaymentCreditCardRepo{}, catRepo)
 
 	id, actualAmount, err := adapter.CreatePaymentFromBot(&BotCCPaymentInput{
 		CreditCardID:  creditCardID.String(),
 		BankAccountID: bankAccountID.String(),
-		CategoryID:    categoryID.String(),
 		Amount:        15000,
 		Date:          "2026-04-08",
 		PaymentType:   "custom",
@@ -455,18 +483,18 @@ func TestCCPaymentAdapter_Failure(t *testing.T) {
 }
 
 func TestCCPaymentAdapter_FullPayment_ZeroUsedCredit(t *testing.T) {
-	categoryID := uuid.New()
 	bankAccountID := uuid.New()
 	creditCardID := uuid.New()
 	recordID := uuid.New()
+	transferCatID := uuid.New()
 	svc := &mockCCPaymentCashFlowService{createResult: &models.CashFlow{ID: recordID}}
 	cardRepo := &mockCCPaymentCreditCardRepo{card: &models.CreditCard{ID: creditCardID, UsedCredit: 0}}
-	adapter := NewCreditCardPaymentAdapter(svc, cardRepo)
+	catRepo := &mockCCPaymentCategoryRepo{categories: []*models.CashFlowCategory{{ID: transferCatID, Type: models.CashFlowTypeTransferOut}}}
+	adapter := NewCreditCardPaymentAdapter(svc, cardRepo, catRepo)
 
 	id, actualAmount, err := adapter.CreatePaymentFromBot(&BotCCPaymentInput{
 		CreditCardID:  creditCardID.String(),
 		BankAccountID: bankAccountID.String(),
-		CategoryID:    categoryID.String(),
 		Amount:        0,
 		Date:          "2026-04-08",
 		PaymentType:   "full",

--- a/backend/internal/discord/handler.go
+++ b/backend/internal/discord/handler.go
@@ -119,6 +119,7 @@ type AccountBalanceQuerier interface {
 type pendingEntry struct {
 	result            *ParseResult
 	authorID          string
+	createdAt         time.Time
 	awaitingAccount   bool
 	awaitingAccountID bool
 	ccPayment         bool
@@ -176,7 +177,7 @@ func (r realDiscordSession) InteractionRespond(interaction *discordgo.Interactio
 	return r.session.InteractionRespond(interaction, resp)
 }
 
-func NewHandler(parser Parser, creator CashFlowCreator, catLoader CategoryLoader, acctLoader AccountLoader, lang string, opts ...HandlerOption) *Handler {
+func NewHandler(ctx context.Context, parser Parser, creator CashFlowCreator, catLoader CategoryLoader, acctLoader AccountLoader, lang string, opts ...HandlerOption) *Handler {
 	if strings.TrimSpace(lang) == "" {
 		lang = string(LangZhTW)
 	}
@@ -194,6 +195,8 @@ func NewHandler(parser Parser, creator CashFlowCreator, catLoader CategoryLoader
 		opt(h)
 	}
 
+	go h.startCleanup(ctx)
+
 	return h
 }
 
@@ -210,6 +213,33 @@ func WithAccountBalanceQuerier(q AccountBalanceQuerier) HandlerOption {
 
 func WithCCPaymentCreator(c CreditCardPaymentCreator) HandlerOption {
 	return func(h *Handler) { h.ccPaymentCreator = c }
+}
+
+const pendingTTL = 15 * time.Minute
+const cleanupInterval = 5 * time.Minute
+
+func (h *Handler) cleanupExpired() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	now := time.Now()
+	for key, entry := range h.pending {
+		if now.Sub(entry.createdAt) > pendingTTL {
+			delete(h.pending, key)
+		}
+	}
+}
+
+func (h *Handler) startCleanup(ctx context.Context) {
+	ticker := time.NewTicker(cleanupInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			h.cleanupExpired()
+		}
+	}
 }
 
 func (h *Handler) HandleMessage(s *discordgo.Session, m *discordgo.MessageCreate) {
@@ -391,6 +421,7 @@ func (h *Handler) handleCCPayment(s discordSession, channelID string, result *Pa
 	h.pending[key] = pendingEntry{
 		result:        result,
 		authorID:      authorID,
+		createdAt:     time.Now(),
 		ccPayment:     true,
 		ccAmount:      result.Amount,
 		ccPaymentType: result.PaymentType,
@@ -530,6 +561,7 @@ func (h *Handler) handleCCBankSelection(s discordSession, i *discordgo.Interacti
 	h.mu.Unlock()
 
 	confirmKey := randomHexKey()
+	entry.createdAt = time.Now()
 	h.mu.Lock()
 	h.pending[confirmKey] = entry
 	h.mu.Unlock()
@@ -818,7 +850,7 @@ func (h *Handler) sendAccountSelectMenu(s discordSession, channelID string, resu
 	key := hex.EncodeToString(b)
 
 	h.mu.Lock()
-	h.pending[key] = pendingEntry{result: result, authorID: authorID, awaitingAccount: true}
+	h.pending[key] = pendingEntry{result: result, authorID: authorID, createdAt: time.Now(), awaitingAccount: true}
 	h.mu.Unlock()
 
 	customID := "select_account:" + key + ":" + authorID
@@ -870,7 +902,7 @@ func (h *Handler) sendAccountIDMenu(s discordSession, channelID string, result *
 	key := hex.EncodeToString(b)
 
 	h.mu.Lock()
-	h.pending[key] = pendingEntry{result: result, authorID: authorID, awaitingAccountID: true}
+	h.pending[key] = pendingEntry{result: result, authorID: authorID, createdAt: time.Now(), awaitingAccountID: true}
 	h.mu.Unlock()
 
 	customID := "select_account_id:" + key + ":" + authorID
@@ -1035,7 +1067,7 @@ func (h *Handler) storePending(result *ParseResult, authorID string) string {
 	key := randomHexKey()
 
 	h.mu.Lock()
-	h.pending[key] = pendingEntry{result: result, authorID: authorID}
+	h.pending[key] = pendingEntry{result: result, authorID: authorID, createdAt: time.Now()}
 	h.mu.Unlock()
 
 	return "confirm:" + key + ":" + authorID

--- a/backend/internal/discord/handler.go
+++ b/backend/internal/discord/handler.go
@@ -356,7 +356,6 @@ func (h *Handler) handleInteraction(s discordSession, i *discordgo.InteractionCr
 			Amount:        entry.ccAmount,
 			Date:          entry.result.Date,
 			PaymentType:   entry.ccPaymentType,
-			CategoryID:    entry.result.CategoryID,
 		})
 		if err != nil {
 			log.Printf("discord: failed to create cc payment: %v", err)

--- a/backend/internal/discord/handler_test.go
+++ b/backend/internal/discord/handler_test.go
@@ -1288,7 +1288,7 @@ func TestHandleInteraction_CCConfirm_Success(t *testing.T) {
 	h.handleInteraction(session, interaction)
 
 	require.Len(t, ccCreator.createdInputs, 1)
-	require.Equal(t, &BotCCPaymentInput{CreditCardID: "cc-1", BankAccountID: "bank-1", CategoryID: "category-1", Amount: 15000, Date: "2026-04-05", PaymentType: "custom"}, ccCreator.createdInputs[0])
+	require.Equal(t, &BotCCPaymentInput{CreditCardID: "cc-1", BankAccountID: "bank-1", Amount: 15000, Date: "2026-04-05", PaymentType: "custom"}, ccCreator.createdInputs[0])
 	require.Len(t, session.interactionResponses, 1)
 	require.Equal(t, GetMessage(string(LangEn), MsgCCPaymentSuccess), session.interactionResponses[0].Data.Embeds[0].Title)
 	require.Empty(t, session.interactionResponses[0].Data.Components)

--- a/backend/internal/discord/handler_test.go
+++ b/backend/internal/discord/handler_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/bwmarrin/discordgo"
 	"github.com/stretchr/testify/require"
@@ -213,7 +214,7 @@ func TestHandleMessage_SuccessfulParse_SendsPreview(t *testing.T) {
 	creator := &mockCashFlowCreator{}
 	categories := []CategoryInfo{{ID: "expense-food", Name: "Food", Type: "expense"}}
 	loader := &mockCategoryLoader{categories: categories}
-	h := NewHandler(parser, creator, loader, nil, string(LangEn))
+	h := NewHandler(context.Background(), parser, creator, loader, nil, string(LangEn))
 	msg := &discordgo.MessageCreate{Message: &discordgo.Message{
 		ID:        "message-1",
 		ChannelID: "channel-1",
@@ -270,7 +271,7 @@ func TestHandleMessage_NonBookkeeping_Silent(t *testing.T) {
 	session := &mockSession{}
 	parser := &mockParser{result: &ParseResult{IsBookkeeping: false}}
 	loader := &mockCategoryLoader{categories: []CategoryInfo{{ID: "expense-food", Name: "Food", Type: "expense"}}}
-	h := NewHandler(parser, &mockCashFlowCreator{}, loader, nil, string(LangEn))
+	h := NewHandler(context.Background(), parser, &mockCashFlowCreator{}, loader, nil, string(LangEn))
 	msg := &discordgo.MessageCreate{Message: &discordgo.Message{
 		ID:        "message-1",
 		ChannelID: "channel-1",
@@ -293,7 +294,7 @@ func TestHandleMessage_MissingAmount_SendsHint(t *testing.T) {
 		MissingFields: []string{"amount"},
 	}}
 	loader := &mockCategoryLoader{categories: []CategoryInfo{{ID: "expense-food", Name: "Food", Type: "expense"}}}
-	h := NewHandler(parser, &mockCashFlowCreator{}, loader, nil, string(LangEn))
+	h := NewHandler(context.Background(), parser, &mockCashFlowCreator{}, loader, nil, string(LangEn))
 	msg := &discordgo.MessageCreate{Message: &discordgo.Message{
 		ID:        "message-1",
 		ChannelID: "channel-1",
@@ -317,7 +318,7 @@ func TestHandleMessage_CCPayment_MissingAmount(t *testing.T) {
 		Amount:        0,
 		MissingFields: []string{"amount"},
 	}}
-	h := NewHandler(parser, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangEn))
+	h := NewHandler(context.Background(), parser, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangEn))
 
 	h.handleMessage(session, &discordgo.MessageCreate{Message: &discordgo.Message{ID: "message-1", ChannelID: "channel-1", Content: "pay card", Author: &discordgo.User{ID: "author-1"}}})
 
@@ -339,7 +340,7 @@ func TestHandleMessage_CCPayment_ShowsCreditCardMenu(t *testing.T) {
 	acctLoader := &mockAccountLoader{accountsByType: map[string][]AccountInfo{
 		"credit_card": {{ID: "cc-1", Name: "Citi Visa *1234", Type: "credit_card"}, {ID: "cc-2", Name: "Chase *5678", Type: "credit_card"}},
 	}}
-	h := NewHandler(parser, &mockCashFlowCreator{}, &mockCategoryLoader{}, acctLoader, string(LangEn))
+	h := NewHandler(context.Background(), parser, &mockCashFlowCreator{}, &mockCategoryLoader{}, acctLoader, string(LangEn))
 
 	h.handleMessage(session, &discordgo.MessageCreate{Message: &discordgo.Message{ID: "message-1", ChannelID: "channel-1", Content: "pay card 15000", Author: &discordgo.User{ID: "author-1"}}})
 
@@ -361,7 +362,7 @@ func TestHandleMessage_CCPayment_NoCreditCards(t *testing.T) {
 	session := &mockSession{}
 	parser := &mockParser{result: &ParseResult{IsBookkeeping: true, Action: "cc_payment", Amount: 15000, PaymentType: "custom"}}
 	acctLoader := &mockAccountLoader{accountsByType: map[string][]AccountInfo{"credit_card": {}}}
-	h := NewHandler(parser, &mockCashFlowCreator{}, &mockCategoryLoader{}, acctLoader, string(LangEn))
+	h := NewHandler(context.Background(), parser, &mockCashFlowCreator{}, &mockCategoryLoader{}, acctLoader, string(LangEn))
 
 	h.handleMessage(session, &discordgo.MessageCreate{Message: &discordgo.Message{ID: "message-1", ChannelID: "channel-1", Content: "pay card 15000", Author: &discordgo.User{ID: "author-1"}}})
 
@@ -373,7 +374,7 @@ func TestHandleMessage_ChatAction_ZhTW(t *testing.T) {
 	session := &mockSession{}
 	parser := &mockParser{result: &ParseResult{Action: "chat", IsBookkeeping: false}}
 	loader := &mockCategoryLoader{categories: []CategoryInfo{{ID: "expense-food", Name: "Food", Type: "expense"}}}
-	h := NewHandler(parser, &mockCashFlowCreator{}, loader, nil, string(LangZhTW))
+	h := NewHandler(context.Background(), parser, &mockCashFlowCreator{}, loader, nil, string(LangZhTW))
 	msg := &discordgo.MessageCreate{Message: &discordgo.Message{
 		ID:        "message-1",
 		ChannelID: "channel-1",
@@ -391,7 +392,7 @@ func TestHandleMessage_ChatAction_En(t *testing.T) {
 	session := &mockSession{}
 	parser := &mockParser{result: &ParseResult{Action: "chat", IsBookkeeping: false}}
 	loader := &mockCategoryLoader{categories: []CategoryInfo{{ID: "expense-food", Name: "Food", Type: "expense"}}}
-	h := NewHandler(parser, &mockCashFlowCreator{}, loader, nil, string(LangEn))
+	h := NewHandler(context.Background(), parser, &mockCashFlowCreator{}, loader, nil, string(LangEn))
 	msg := &discordgo.MessageCreate{Message: &discordgo.Message{
 		ID:        "message-1",
 		ChannelID: "channel-1",
@@ -409,7 +410,7 @@ func TestHandleMessage_UnsupportedAction_ZhTW(t *testing.T) {
 	session := &mockSession{}
 	parser := &mockParser{result: &ParseResult{Action: "unsupported", IsBookkeeping: false}}
 	loader := &mockCategoryLoader{categories: []CategoryInfo{{ID: "expense-food", Name: "Food", Type: "expense"}}}
-	h := NewHandler(parser, &mockCashFlowCreator{}, loader, nil, string(LangZhTW))
+	h := NewHandler(context.Background(), parser, &mockCashFlowCreator{}, loader, nil, string(LangZhTW))
 	msg := &discordgo.MessageCreate{Message: &discordgo.Message{
 		ID:        "message-1",
 		ChannelID: "channel-1",
@@ -427,7 +428,7 @@ func TestHandleMessage_UnsupportedAction_En(t *testing.T) {
 	session := &mockSession{}
 	parser := &mockParser{result: &ParseResult{Action: "unsupported", IsBookkeeping: false}}
 	loader := &mockCategoryLoader{categories: []CategoryInfo{{ID: "expense-food", Name: "Food", Type: "expense"}}}
-	h := NewHandler(parser, &mockCashFlowCreator{}, loader, nil, string(LangEn))
+	h := NewHandler(context.Background(), parser, &mockCashFlowCreator{}, loader, nil, string(LangEn))
 	msg := &discordgo.MessageCreate{Message: &discordgo.Message{
 		ID:        "message-1",
 		ChannelID: "channel-1",
@@ -445,7 +446,7 @@ func TestHandleMessage_CategoryLoadFail_SpecificError(t *testing.T) {
 	session := &mockSession{}
 	parser := &mockParser{}
 	loader := &mockCategoryLoader{err: errors.New("db down")}
-	h := NewHandler(parser, &mockCashFlowCreator{}, loader, nil, string(LangEn))
+	h := NewHandler(context.Background(), parser, &mockCashFlowCreator{}, loader, nil, string(LangEn))
 	msg := &discordgo.MessageCreate{Message: &discordgo.Message{
 		ID:        "message-1",
 		ChannelID: "channel-1",
@@ -464,7 +465,7 @@ func TestHandleMessage_ParseFail_SpecificError(t *testing.T) {
 	session := &mockSession{}
 	parser := &mockParser{err: errors.New("parser down")}
 	loader := &mockCategoryLoader{categories: []CategoryInfo{{ID: "expense-food", Name: "Food", Type: "expense"}}}
-	h := NewHandler(parser, &mockCashFlowCreator{}, loader, nil, string(LangEn))
+	h := NewHandler(context.Background(), parser, &mockCashFlowCreator{}, loader, nil, string(LangEn))
 	msg := &discordgo.MessageCreate{Message: &discordgo.Message{
 		ID:        "message-1",
 		ChannelID: "channel-1",
@@ -490,7 +491,7 @@ func TestHandleInteraction_Confirm_CreatesRecord(t *testing.T) {
 		Date:          "2026-04-05",
 	}
 	creator := &mockCashFlowCreator{resultID: "cashflow-1"}
-	h := NewHandler(&mockParser{}, creator, &mockCategoryLoader{}, nil, string(LangEn))
+	h := NewHandler(context.Background(), &mockParser{}, creator, &mockCategoryLoader{}, nil, string(LangEn))
 	customID := h.storePending(result, "author-1")
 	interaction := newComponentInteraction(customID, "author-1")
 
@@ -515,7 +516,7 @@ func TestHandleInteraction_Confirm_CreatesRecord(t *testing.T) {
 func TestHandleInteraction_Cancel_UpdatesEmbed(t *testing.T) {
 	session := &mockSession{}
 	creator := &mockCashFlowCreator{}
-	h := NewHandler(&mockParser{}, creator, &mockCategoryLoader{}, nil, string(LangEn))
+	h := NewHandler(context.Background(), &mockParser{}, creator, &mockCategoryLoader{}, nil, string(LangEn))
 	interaction := newComponentInteraction("cancel:author-1", "author-1")
 
 	h.handleInteraction(session, interaction)
@@ -541,7 +542,7 @@ func TestHandleInteraction_WrongUser_Ephemeral(t *testing.T) {
 		Date:          "2026-04-05",
 	}
 	creator := &mockCashFlowCreator{}
-	h := NewHandler(&mockParser{}, creator, &mockCategoryLoader{}, nil, string(LangEn))
+	h := NewHandler(context.Background(), &mockParser{}, creator, &mockCategoryLoader{}, nil, string(LangEn))
 	customID := h.storePending(result, "author-1")
 	interaction := newComponentInteraction(customID, "other-user")
 
@@ -568,7 +569,7 @@ func TestHandleMessage_EmptySourceType_SendsSelectMenu(t *testing.T) {
 		SourceType:    "",
 	}}
 	loader := &mockCategoryLoader{categories: []CategoryInfo{{ID: "expense-food", Name: "Food", Type: "expense"}}}
-	h := NewHandler(parser, &mockCashFlowCreator{}, loader, nil, string(LangEn))
+	h := NewHandler(context.Background(), parser, &mockCashFlowCreator{}, loader, nil, string(LangEn))
 	msg := &discordgo.MessageCreate{Message: &discordgo.Message{
 		ID:        "message-1",
 		ChannelID: "channel-1",
@@ -607,7 +608,7 @@ func TestHandleMessage_CreditCard_ShowsAccountIDMenu(t *testing.T) {
 	acctLoader := &mockAccountLoader{accounts: []AccountInfo{
 		{ID: "cc-1", Name: "中信 Visa *1234", Type: "credit_card"},
 	}}
-	h := NewHandler(parser, &mockCashFlowCreator{}, loader, acctLoader, string(LangEn))
+	h := NewHandler(context.Background(), parser, &mockCashFlowCreator{}, loader, acctLoader, string(LangEn))
 	msg := &discordgo.MessageCreate{Message: &discordgo.Message{
 		ID:        "message-1",
 		ChannelID: "channel-1",
@@ -643,7 +644,7 @@ func TestHandleMessage_Cash_SendsPreviewDirectly(t *testing.T) {
 		SourceType:    "cash",
 	}}
 	loader := &mockCategoryLoader{categories: []CategoryInfo{{ID: "expense-food", Name: "Food", Type: "expense"}}}
-	h := NewHandler(parser, &mockCashFlowCreator{}, loader, nil, string(LangEn))
+	h := NewHandler(context.Background(), parser, &mockCashFlowCreator{}, loader, nil, string(LangEn))
 	msg := &discordgo.MessageCreate{Message: &discordgo.Message{
 		ID:        "message-1",
 		ChannelID: "channel-1",
@@ -671,7 +672,7 @@ func TestHandleMessage_RoutesToCreateFlow(t *testing.T) {
 		Date:          "2026-04-05",
 		SourceType:    "cash",
 	}}
-	h := NewHandler(parser, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangEn))
+	h := NewHandler(context.Background(), parser, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangEn))
 	msg := &discordgo.MessageCreate{Message: &discordgo.Message{
 		ID:        "message-1",
 		ChannelID: "channel-1",
@@ -698,7 +699,7 @@ func TestHandleMessage_CreateAction_RegressionIdentical(t *testing.T) {
 		Date:          "2026-04-05",
 		SourceType:    "",
 	}}
-	h := NewHandler(parser, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangEn))
+	h := NewHandler(context.Background(), parser, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangEn))
 
 	h.handleMessage(session, &discordgo.MessageCreate{Message: &discordgo.Message{ID: "message-1", ChannelID: "channel-1", Content: "lunch 180", Author: &discordgo.User{ID: "author-1"}}})
 
@@ -713,7 +714,7 @@ func TestHandleMessage_CreateAction_RegressionIdentical(t *testing.T) {
 func TestHandleMessage_BackwardCompat_NoActionField(t *testing.T) {
 	session := &mockSession{}
 	parser := &mockParser{result: &ParseResult{IsBookkeeping: false, Action: ""}}
-	h := NewHandler(parser, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangEn))
+	h := NewHandler(context.Background(), parser, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangEn))
 
 	h.handleMessage(session, &discordgo.MessageCreate{Message: &discordgo.Message{ID: "message-1", ChannelID: "channel-1", Content: "hi there", Author: &discordgo.User{ID: "author-1"}}})
 
@@ -733,7 +734,7 @@ func TestHandleMessage_CreateWithQueryParams_IgnoresParams(t *testing.T) {
 		SourceType:    "cash",
 		QueryParams:   &QueryParams{Month: 3, Year: 2026},
 	}}
-	h := NewHandler(parser, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangEn))
+	h := NewHandler(context.Background(), parser, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangEn))
 
 	h.handleMessage(session, &discordgo.MessageCreate{Message: &discordgo.Message{ID: "message-1", ChannelID: "channel-1", Content: "lunch 320", Author: &discordgo.User{ID: "author-1"}}})
 
@@ -753,7 +754,7 @@ func TestHandleMessage_RoutesToQueryFlow(t *testing.T) {
 		QueryParams:   &QueryParams{Year: 2026, Month: 4},
 	}}
 	cfQuerier := &mockCashFlowQuerier{result: &MonthlySummaryResult{Year: 2026, Month: 4, TotalIncome: 1000, TotalExpense: 500, NetCashFlow: 500}}
-	h := NewHandler(parser, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangZhTW), WithCashFlowQuerier(cfQuerier))
+	h := NewHandler(context.Background(), parser, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangZhTW), WithCashFlowQuerier(cfQuerier))
 	msg := &discordgo.MessageCreate{Message: &discordgo.Message{
 		ID:        "message-1",
 		ChannelID: "channel-1",
@@ -773,7 +774,7 @@ func TestHandleMessage_RoutesToQueryFlow(t *testing.T) {
 func TestHandleMessage_ChatIgnored(t *testing.T) {
 	session := &mockSession{}
 	parser := &mockParser{result: &ParseResult{IsBookkeeping: false, Action: ""}}
-	h := NewHandler(parser, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangEn))
+	h := NewHandler(context.Background(), parser, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangEn))
 	msg := &discordgo.MessageCreate{Message: &discordgo.Message{
 		ID:        "message-1",
 		ChannelID: "channel-1",
@@ -789,7 +790,7 @@ func TestHandleMessage_ChatIgnored(t *testing.T) {
 func TestHandleMessage_ConcurrentQueryAndCreate(t *testing.T) {
 	t.Parallel()
 
-	h := NewHandler(
+	h := NewHandler(context.Background(),
 		&mockParser{parseFunc: func(_ context.Context, message string, _ []CategoryInfo) (*ParseResult, error) {
 			if message == "query" {
 				return &ParseResult{
@@ -837,7 +838,7 @@ func TestHandleMessage_ConcurrentQueryAndCreate(t *testing.T) {
 func TestHandleQuery_UnsupportedType(t *testing.T) {
 	session := &mockSession{}
 	parser := &mockParser{result: &ParseResult{IsBookkeeping: true, Action: "query", QueryType: "unknown", QueryParams: &QueryParams{Year: 2026, Month: 4}}}
-	h := NewHandler(parser, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangEn))
+	h := NewHandler(context.Background(), parser, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangEn))
 	msg := &discordgo.MessageCreate{Message: &discordgo.Message{
 		ID:        "message-1",
 		ChannelID: "channel-1",
@@ -870,7 +871,7 @@ func TestHandleCashFlowQuery_CurrentMonth_GivenSummary_WhenHandleMessage_ThenSen
 		TopCategories: []CategoryBreakdown{{Name: "飲食", Amount: 5000}, {Name: "交通", Amount: 3000}},
 		Comparison:    &MonthComparisonResult{ExpenseChange: 1200, ExpenseChangePct: 5.4, IncomeChange: 8000, IncomeChangePct: 11.1},
 	}}
-	h := NewHandler(parser, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangZhTW), WithCashFlowQuerier(cfQuerier))
+	h := NewHandler(context.Background(), parser, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangZhTW), WithCashFlowQuerier(cfQuerier))
 
 	h.handleMessage(session, &discordgo.MessageCreate{Message: &discordgo.Message{ID: "message-1", ChannelID: "channel-1", Content: "本月現金流", Author: &discordgo.User{ID: "author-1"}}})
 
@@ -892,7 +893,7 @@ func TestHandleCashFlowQuery_SpecificMonth_GivenMonthParam_WhenHandleMessage_The
 	session := &mockSession{}
 	parser := &mockParser{result: &ParseResult{IsBookkeeping: true, Action: "query", QueryType: "cash_flow_summary", QueryParams: &QueryParams{Year: 2026, Month: 3}}}
 	cfQuerier := &mockCashFlowQuerier{result: &MonthlySummaryResult{Year: 2026, Month: 3, TotalIncome: 1, TotalExpense: 1, NetCashFlow: 0}}
-	h := NewHandler(parser, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangZhTW), WithCashFlowQuerier(cfQuerier))
+	h := NewHandler(context.Background(), parser, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangZhTW), WithCashFlowQuerier(cfQuerier))
 
 	h.handleMessage(session, &discordgo.MessageCreate{Message: &discordgo.Message{ID: "message-1", ChannelID: "channel-1", Content: "3月支出", Author: &discordgo.User{ID: "author-1"}}})
 
@@ -910,7 +911,7 @@ func TestHandleCashFlowQuery_WithCategory_GivenCategoryParam_WhenHandleMessage_T
 		NetCashFlow:   56500,
 		TopCategories: []CategoryBreakdown{{Name: "飲食", Amount: 5000, Count: 3}},
 	}}
-	h := NewHandler(parser, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangZhTW), WithCashFlowQuerier(cfQuerier))
+	h := NewHandler(context.Background(), parser, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangZhTW), WithCashFlowQuerier(cfQuerier))
 
 	h.handleMessage(session, &discordgo.MessageCreate{Message: &discordgo.Message{ID: "message-1", ChannelID: "channel-1", Content: "4月飲食支出", Author: &discordgo.User{ID: "author-1"}}})
 
@@ -923,7 +924,7 @@ func TestHandleCashFlowQuery_NoData_GivenZeroSummary_WhenHandleMessage_ThenShowE
 	session := &mockSession{}
 	parser := &mockParser{result: &ParseResult{IsBookkeeping: true, Action: "query", QueryType: "cash_flow_summary", QueryParams: &QueryParams{Year: 2026, Month: 4}}}
 	cfQuerier := &mockCashFlowQuerier{result: &MonthlySummaryResult{Year: 2026, Month: 4}}
-	h := NewHandler(parser, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangZhTW), WithCashFlowQuerier(cfQuerier))
+	h := NewHandler(context.Background(), parser, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangZhTW), WithCashFlowQuerier(cfQuerier))
 
 	h.handleMessage(session, &discordgo.MessageCreate{Message: &discordgo.Message{ID: "message-1", ChannelID: "channel-1", Content: "本月摘要", Author: &discordgo.User{ID: "author-1"}}})
 
@@ -934,7 +935,7 @@ func TestHandleCashFlowQuery_ServiceError_GivenServiceFailure_WhenHandleMessage_
 	session := &mockSession{}
 	parser := &mockParser{result: &ParseResult{IsBookkeeping: true, Action: "query", QueryType: "cash_flow_summary", QueryParams: &QueryParams{Year: 2026, Month: 4}}}
 	cfQuerier := &mockCashFlowQuerier{err: errors.New("boom")}
-	h := NewHandler(parser, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangEn), WithCashFlowQuerier(cfQuerier))
+	h := NewHandler(context.Background(), parser, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangEn), WithCashFlowQuerier(cfQuerier))
 
 	h.handleMessage(session, &discordgo.MessageCreate{Message: &discordgo.Message{ID: "message-1", ChannelID: "channel-1", Content: "cash flow", Author: &discordgo.User{ID: "author-1"}}})
 
@@ -946,7 +947,7 @@ func TestHandleCashFlowQuery_Fail_SpecificError(t *testing.T) {
 	session := &mockSession{}
 	parser := &mockParser{result: &ParseResult{IsBookkeeping: true, Action: "query", QueryType: "cash_flow_summary", QueryParams: &QueryParams{Year: 2026, Month: 4}}}
 	cfQuerier := &mockCashFlowQuerier{err: errors.New("boom")}
-	h := NewHandler(parser, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangZhTW), WithCashFlowQuerier(cfQuerier))
+	h := NewHandler(context.Background(), parser, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangZhTW), WithCashFlowQuerier(cfQuerier))
 
 	h.handleMessage(session, &discordgo.MessageCreate{Message: &discordgo.Message{ID: "message-1", ChannelID: "channel-1", Content: "本月摘要", Author: &discordgo.User{ID: "author-1"}}})
 
@@ -961,7 +962,7 @@ func TestHandleAccountBalanceQuery_BankAndCC_GivenBalances_WhenHandleMessage_The
 		BankAccounts: []BankAccountBalance{{Name: "中信銀行", Last4: "1234", Balance: 25000}, {Name: "台新銀行", Last4: "5678", Balance: 12000}},
 		CreditCards:  []CreditCardBalance{{Name: "中信 Visa", Last4: "4321", CreditLimit: 100000, UsedCredit: 20000, Remaining: 80000, UsagePct: 20}},
 	}}
-	h := NewHandler(parser, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangZhTW), WithAccountBalanceQuerier(acctQuerier))
+	h := NewHandler(context.Background(), parser, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangZhTW), WithAccountBalanceQuerier(acctQuerier))
 
 	h.handleMessage(session, &discordgo.MessageCreate{Message: &discordgo.Message{ID: "message-1", ChannelID: "channel-1", Content: "帳戶餘額", Author: &discordgo.User{ID: "author-1"}}})
 
@@ -979,7 +980,7 @@ func TestHandleAccountBalanceQuery_CCNearingLimit_GivenHighUsage_WhenHandleMessa
 	session := &mockSession{}
 	parser := &mockParser{result: &ParseResult{IsBookkeeping: true, Action: "query", QueryType: "account_balance", QueryParams: &QueryParams{Year: 2026, Month: 4}}}
 	acctQuerier := &mockAccountBalanceQuerier{result: &AccountBalancesResult{CreditCards: []CreditCardBalance{{Name: "中信 Visa", Last4: "4321", CreditLimit: 100000, UsedCredit: 85000, Remaining: 15000, UsagePct: 85}}}}
-	h := NewHandler(parser, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangZhTW), WithAccountBalanceQuerier(acctQuerier))
+	h := NewHandler(context.Background(), parser, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangZhTW), WithAccountBalanceQuerier(acctQuerier))
 
 	h.handleMessage(session, &discordgo.MessageCreate{Message: &discordgo.Message{ID: "message-1", ChannelID: "channel-1", Content: "信用卡額度", Author: &discordgo.User{ID: "author-1"}}})
 
@@ -990,7 +991,7 @@ func TestHandleAccountBalanceQuery_NoAccounts_GivenEmptyResult_WhenHandleMessage
 	session := &mockSession{}
 	parser := &mockParser{result: &ParseResult{IsBookkeeping: true, Action: "query", QueryType: "account_balance", QueryParams: &QueryParams{Year: 2026, Month: 4}}}
 	acctQuerier := &mockAccountBalanceQuerier{result: &AccountBalancesResult{}}
-	h := NewHandler(parser, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangZhTW), WithAccountBalanceQuerier(acctQuerier))
+	h := NewHandler(context.Background(), parser, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangZhTW), WithAccountBalanceQuerier(acctQuerier))
 
 	h.handleMessage(session, &discordgo.MessageCreate{Message: &discordgo.Message{ID: "message-1", ChannelID: "channel-1", Content: "餘額", Author: &discordgo.User{ID: "author-1"}}})
 
@@ -1001,7 +1002,7 @@ func TestHandleAccountBalanceQuery_PartialFailure_GivenBankOKAndCCError_WhenHand
 	session := &mockSession{}
 	parser := &mockParser{result: &ParseResult{IsBookkeeping: true, Action: "query", QueryType: "account_balance", QueryParams: &QueryParams{Year: 2026, Month: 4}}}
 	acctQuerier := &mockAccountBalanceQuerier{result: &AccountBalancesResult{BankAccounts: []BankAccountBalance{{Name: "中信銀行", Last4: "1234", Balance: 25000}}, CCError: errors.New("cc down")}}
-	h := NewHandler(parser, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangZhTW), WithAccountBalanceQuerier(acctQuerier))
+	h := NewHandler(context.Background(), parser, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangZhTW), WithAccountBalanceQuerier(acctQuerier))
 
 	h.handleMessage(session, &discordgo.MessageCreate{Message: &discordgo.Message{ID: "message-1", ChannelID: "channel-1", Content: "帳戶餘額", Author: &discordgo.User{ID: "author-1"}}})
 
@@ -1014,7 +1015,7 @@ func TestHandleAccountBalanceQuery_Fail_SpecificError(t *testing.T) {
 	session := &mockSession{}
 	parser := &mockParser{result: &ParseResult{IsBookkeeping: true, Action: "query", QueryType: "account_balance", QueryParams: &QueryParams{Year: 2026, Month: 4}}}
 	acctQuerier := &mockAccountBalanceQuerier{err: errors.New("boom")}
-	h := NewHandler(parser, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangEn), WithAccountBalanceQuerier(acctQuerier))
+	h := NewHandler(context.Background(), parser, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangEn), WithAccountBalanceQuerier(acctQuerier))
 
 	h.handleMessage(session, &discordgo.MessageCreate{Message: &discordgo.Message{ID: "message-1", ChannelID: "channel-1", Content: "balances", Author: &discordgo.User{ID: "author-1"}}})
 
@@ -1034,7 +1035,7 @@ func TestHandleInteraction_SelectMenu_CashGoesToPreview(t *testing.T) {
 		Date:          "2026-04-05",
 		SourceType:    "",
 	}
-	h := NewHandler(&mockParser{}, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangEn))
+	h := NewHandler(context.Background(), &mockParser{}, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangEn))
 
 	h.mu.Lock()
 	h.pending["test-key"] = pendingEntry{result: result, authorID: "author-1", awaitingAccount: true}
@@ -1072,7 +1073,7 @@ func TestHandleInteraction_SelectMenu_WrongUser_Ephemeral(t *testing.T) {
 		Amount:        180,
 		SourceType:    "",
 	}
-	h := NewHandler(&mockParser{}, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangEn))
+	h := NewHandler(context.Background(), &mockParser{}, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangEn))
 
 	h.mu.Lock()
 	h.pending["test-key"] = pendingEntry{result: result, authorID: "author-1", awaitingAccount: true}
@@ -1099,7 +1100,7 @@ func TestHandleInteraction_SelectMenu_WrongUser_Ephemeral(t *testing.T) {
 }
 
 func TestBuildPreviewEmbed_IncludesPaymentMethodAndFooter(t *testing.T) {
-	h := NewHandler(&mockParser{}, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangEn))
+	h := NewHandler(context.Background(), &mockParser{}, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangEn))
 	result := &ParseResult{
 		IsBookkeeping: true,
 		Type:          "expense",
@@ -1136,7 +1137,7 @@ func TestHandleInteraction_Confirm_PassesSourceType(t *testing.T) {
 		SourceType:    "credit_card",
 	}
 	creator := &mockCashFlowCreator{resultID: "cashflow-1"}
-	h := NewHandler(&mockParser{}, creator, &mockCategoryLoader{}, nil, string(LangEn))
+	h := NewHandler(context.Background(), &mockParser{}, creator, &mockCategoryLoader{}, nil, string(LangEn))
 	customID := h.storePending(result, "author-1")
 	interaction := newComponentInteraction(customID, "author-1")
 
@@ -1152,7 +1153,7 @@ func TestHandleInteraction_CCSelectCard_ShowsBankMenu(t *testing.T) {
 		"credit_card":  {{ID: "cc-1", Name: "Citi Visa *1234", Type: "credit_card"}},
 		"bank_account": {{ID: "bank-1", Name: "Chase Bank *8888", Type: "bank_account"}},
 	}}
-	h := NewHandler(&mockParser{}, &mockCashFlowCreator{}, &mockCategoryLoader{}, acctLoader, string(LangEn))
+	h := NewHandler(context.Background(), &mockParser{}, &mockCashFlowCreator{}, &mockCategoryLoader{}, acctLoader, string(LangEn))
 
 	h.mu.Lock()
 	h.pending["cc-key"] = pendingEntry{result: &ParseResult{Action: "cc_payment", Amount: 15000, Date: "2026-04-05", PaymentType: "custom"}, authorID: "author-1", ccPayment: true, ccAmount: 15000, ccPaymentType: "custom"}
@@ -1186,7 +1187,7 @@ func TestHandleInteraction_CCSelectCard_NoBankAccounts(t *testing.T) {
 		"credit_card":  {{ID: "cc-1", Name: "Citi Visa *1234", Type: "credit_card"}},
 		"bank_account": {},
 	}}
-	h := NewHandler(&mockParser{}, &mockCashFlowCreator{}, &mockCategoryLoader{}, acctLoader, string(LangEn))
+	h := NewHandler(context.Background(), &mockParser{}, &mockCashFlowCreator{}, &mockCategoryLoader{}, acctLoader, string(LangEn))
 
 	h.mu.Lock()
 	h.pending["cc-key"] = pendingEntry{result: &ParseResult{Action: "cc_payment", Amount: 15000, Date: "2026-04-05", PaymentType: "custom"}, authorID: "author-1", ccPayment: true, ccAmount: 15000, ccPaymentType: "custom"}
@@ -1209,7 +1210,7 @@ func TestHandleInteraction_CCSelectCard_NoBankAccounts(t *testing.T) {
 
 func TestHandleInteraction_CCSelectBank_ShowsPreview(t *testing.T) {
 	session := &mockSession{}
-	h := NewHandler(&mockParser{}, &mockCashFlowCreator{}, &mockCategoryLoader{}, &mockAccountLoader{accountsByType: map[string][]AccountInfo{
+	h := NewHandler(context.Background(), &mockParser{}, &mockCashFlowCreator{}, &mockCategoryLoader{}, &mockAccountLoader{accountsByType: map[string][]AccountInfo{
 		"bank_account": {{ID: "bank-1", Name: "Chase Bank *8888", Type: "bank_account"}},
 	}}, string(LangEn))
 
@@ -1262,7 +1263,7 @@ func TestHandleInteraction_CCSelectBank_ShowsPreview(t *testing.T) {
 func TestHandleInteraction_CCConfirm_Success(t *testing.T) {
 	session := &mockSession{}
 	ccCreator := &mockCCPaymentCreator{resultID: "payment-1", resultAmount: 15000}
-	h := NewHandler(&mockParser{}, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangEn), WithCCPaymentCreator(ccCreator))
+	h := NewHandler(context.Background(), &mockParser{}, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangEn), WithCCPaymentCreator(ccCreator))
 
 	h.mu.Lock()
 	h.pending["confirm-key"] = pendingEntry{
@@ -1297,7 +1298,7 @@ func TestHandleInteraction_CCConfirm_Success(t *testing.T) {
 func TestHandleInteraction_CCConfirm_Failure(t *testing.T) {
 	session := &mockSession{}
 	ccCreator := &mockCCPaymentCreator{err: errors.New("payment failed")}
-	h := NewHandler(&mockParser{}, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangEn), WithCCPaymentCreator(ccCreator))
+	h := NewHandler(context.Background(), &mockParser{}, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangEn), WithCCPaymentCreator(ccCreator))
 
 	h.mu.Lock()
 	h.pending["confirm-key"] = pendingEntry{
@@ -1328,7 +1329,7 @@ func TestHandleInteraction_CCConfirm_Failure(t *testing.T) {
 
 func TestHandleInteraction_CCCancel(t *testing.T) {
 	session := &mockSession{}
-	h := NewHandler(&mockParser{}, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangEn))
+	h := NewHandler(context.Background(), &mockParser{}, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangEn))
 	interaction := &discordgo.InteractionCreate{Interaction: &discordgo.Interaction{
 		Type:    discordgo.InteractionMessageComponent,
 		Member:  &discordgo.Member{User: &discordgo.User{ID: "author-1"}},
@@ -1358,7 +1359,7 @@ func TestHandleInteraction_SelectBankAccount_ShowsSecondSelectMenu(t *testing.T)
 		{ID: "acct-1", Name: "中信銀行 *1234", Type: "bank_account"},
 		{ID: "acct-2", Name: "台新銀行 *5678", Type: "bank_account"},
 	}}
-	h := NewHandler(&mockParser{}, &mockCashFlowCreator{}, &mockCategoryLoader{}, acctLoader, string(LangEn))
+	h := NewHandler(context.Background(), &mockParser{}, &mockCashFlowCreator{}, &mockCategoryLoader{}, acctLoader, string(LangEn))
 
 	h.mu.Lock()
 	h.pending["test-key"] = pendingEntry{result: result, authorID: "author-1", awaitingAccount: true}
@@ -1403,7 +1404,7 @@ func TestHandleInteraction_SelectCash_SkipsSecondMenu(t *testing.T) {
 		Date:          "2026-04-05",
 		SourceType:    "",
 	}
-	h := NewHandler(&mockParser{}, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangEn))
+	h := NewHandler(context.Background(), &mockParser{}, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangEn))
 
 	h.mu.Lock()
 	h.pending["test-key"] = pendingEntry{result: result, authorID: "author-1", awaitingAccount: true}
@@ -1441,7 +1442,7 @@ func TestHandleInteraction_SelectAccountID_UpdatesPendingAndShowsPreview(t *test
 		Date:          "2026-04-05",
 		SourceType:    "bank_account",
 	}
-	h := NewHandler(&mockParser{}, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangEn))
+	h := NewHandler(context.Background(), &mockParser{}, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangEn))
 
 	h.mu.Lock()
 	h.pending["test-key"] = pendingEntry{result: result, authorID: "author-1", awaitingAccountID: true}
@@ -1482,7 +1483,7 @@ func TestHandleInteraction_Confirm_PassesSourceID(t *testing.T) {
 		SourceID:      "acct-uuid-1",
 	}
 	creator := &mockCashFlowCreator{resultID: "cashflow-1"}
-	h := NewHandler(&mockParser{}, creator, &mockCategoryLoader{}, nil, string(LangEn))
+	h := NewHandler(context.Background(), &mockParser{}, creator, &mockCategoryLoader{}, nil, string(LangEn))
 	customID := h.storePending(result, "author-1")
 	interaction := newComponentInteraction(customID, "author-1")
 
@@ -1508,4 +1509,98 @@ func newComponentInteraction(customID string, userID string) *discordgo.Interact
 
 func TestMonthNameForQueryTitle_English(t *testing.T) {
 	require.Equal(t, "April", fmt.Sprintf("%s", monthLabel(string(LangEn), 4)))
+}
+
+func TestCleanupExpired_RemovesOldEntries(t *testing.T) {
+	t.Parallel()
+
+	h := NewHandler(context.Background(), &mockParser{}, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangEn))
+
+	h.mu.Lock()
+	h.pending["old-key"] = pendingEntry{
+		result:    &ParseResult{},
+		authorID:  "author-1",
+		createdAt: time.Now().Add(-20 * time.Minute),
+	}
+	h.mu.Unlock()
+
+	h.cleanupExpired()
+
+	h.mu.Lock()
+	_, exists := h.pending["old-key"]
+	h.mu.Unlock()
+
+	require.False(t, exists, "expired entry should be removed")
+}
+
+func TestCleanupExpired_KeepsFreshEntries(t *testing.T) {
+	t.Parallel()
+
+	h := NewHandler(context.Background(), &mockParser{}, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangEn))
+
+	h.mu.Lock()
+	h.pending["fresh-key"] = pendingEntry{
+		result:    &ParseResult{},
+		authorID:  "author-1",
+		createdAt: time.Now(),
+	}
+	h.mu.Unlock()
+
+	h.cleanupExpired()
+
+	h.mu.Lock()
+	_, exists := h.pending["fresh-key"]
+	h.mu.Unlock()
+
+	require.True(t, exists, "fresh entry should be kept")
+}
+
+func TestCleanupExpired_RemovesMultipleExpired(t *testing.T) {
+	t.Parallel()
+
+	h := NewHandler(context.Background(), &mockParser{}, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangEn))
+
+	h.mu.Lock()
+	h.pending["old-1"] = pendingEntry{result: &ParseResult{}, authorID: "a", createdAt: time.Now().Add(-20 * time.Minute)}
+	h.pending["old-2"] = pendingEntry{result: &ParseResult{}, authorID: "b", createdAt: time.Now().Add(-30 * time.Minute)}
+	h.pending["old-3"] = pendingEntry{result: &ParseResult{}, authorID: "c", createdAt: time.Now().Add(-60 * time.Minute)}
+	h.pending["fresh-1"] = pendingEntry{result: &ParseResult{}, authorID: "d", createdAt: time.Now()}
+	h.mu.Unlock()
+
+	h.cleanupExpired()
+
+	h.mu.Lock()
+	remaining := len(h.pending)
+	_, freshExists := h.pending["fresh-1"]
+	h.mu.Unlock()
+
+	require.Equal(t, 1, remaining, "only fresh entry should remain")
+	require.True(t, freshExists, "fresh entry should be kept")
+}
+
+func TestStartCleanup_StopsOnContextCancel(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	h := NewHandler(ctx, &mockParser{}, &mockCashFlowCreator{}, &mockCategoryLoader{}, nil, string(LangEn))
+
+	// Add an expired entry
+	h.mu.Lock()
+	h.pending["old-key"] = pendingEntry{result: &ParseResult{}, authorID: "a", createdAt: time.Now().Add(-20 * time.Minute)}
+	h.mu.Unlock()
+
+	// Cancel the context to stop the cleanup goroutine
+	cancel()
+
+	// Give the goroutine time to exit
+	time.Sleep(50 * time.Millisecond)
+
+	// The entry should still be there since the cleanup ticker (5 min) hasn't fired
+	// and the goroutine should have exited due to context cancellation.
+	// Manually call cleanupExpired to verify entries are still removable.
+	h.mu.Lock()
+	_, exists := h.pending["old-key"]
+	h.mu.Unlock()
+
+	require.True(t, exists, "entry should still exist since ticker didn't fire before cancel")
 }

--- a/backend/internal/discord/integration_test.go
+++ b/backend/internal/discord/integration_test.go
@@ -535,7 +535,6 @@ func TestIntegration_CCPayment_FullFlow(t *testing.T) {
 	assert.Equal(t, &BotCCPaymentInput{
 		CreditCardID:  "cc-uuid-1",
 		BankAccountID: "bank-uuid-1",
-		CategoryID:    "cat-transfer",
 		Amount:        15000,
 		Date:          "2026-04-05",
 		PaymentType:   "custom",

--- a/backend/internal/discord/integration_test.go
+++ b/backend/internal/discord/integration_test.go
@@ -1,6 +1,7 @@
 package discord
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -26,7 +27,7 @@ func TestIntegration_MessageToConfirmToCreate(t *testing.T) {
 	loader := &mockCategoryLoader{categories: []CategoryInfo{
 		{ID: "cat-food", Name: "飲食", Type: "expense"},
 	}}
-	h := NewHandler(parser, creator, loader, nil, string(LangZhTW))
+	h := NewHandler(context.Background(), parser, creator, loader, nil, string(LangZhTW))
 
 	msg := &discordgo.MessageCreate{Message: &discordgo.Message{
 		ID: "msg-1", ChannelID: "ch-1", Content: "午餐拉麵 180",
@@ -91,7 +92,7 @@ func TestIntegration_MessageToCancelFlow(t *testing.T) {
 	loader := &mockCategoryLoader{categories: []CategoryInfo{
 		{ID: "cat-food", Name: "飲食", Type: "expense"},
 	}}
-	h := NewHandler(parser, creator, loader, nil, string(LangZhTW))
+	h := NewHandler(context.Background(), parser, creator, loader, nil, string(LangZhTW))
 
 	msg := &discordgo.MessageCreate{Message: &discordgo.Message{
 		ID: "msg-2", ChannelID: "ch-1", Content: "咖啡 50",
@@ -122,7 +123,7 @@ func TestIntegration_MessageToCancelFlow(t *testing.T) {
 }
 
 func TestStorePending_CustomIDFormat(t *testing.T) {
-	h := NewHandler(&mockParser{}, &mockCashFlowCreator{}, nil, nil, string(LangZhTW))
+	h := NewHandler(context.Background(), &mockParser{}, &mockCashFlowCreator{}, nil, nil, string(LangZhTW))
 	result := &ParseResult{
 		IsBookkeeping: true,
 		Type:          "expense",
@@ -139,7 +140,7 @@ func TestStorePending_CustomIDFormat(t *testing.T) {
 }
 
 func TestPopPending_RetrievesAndRemoves(t *testing.T) {
-	h := NewHandler(&mockParser{}, &mockCashFlowCreator{}, nil, nil, string(LangZhTW))
+	h := NewHandler(context.Background(), &mockParser{}, &mockCashFlowCreator{}, nil, nil, string(LangZhTW))
 	result := &ParseResult{Type: "expense", Amount: 42}
 
 	customID := h.storePending(result, "user-1")
@@ -172,7 +173,7 @@ func TestIntegration_YesterdayDate_PassedToRecord(t *testing.T) {
 	loader := &mockCategoryLoader{categories: []CategoryInfo{
 		{ID: "cat-food", Name: "飲食", Type: "expense"},
 	}}
-	h := NewHandler(parser, creator, loader, nil, string(LangZhTW))
+	h := NewHandler(context.Background(), parser, creator, loader, nil, string(LangZhTW))
 
 	msg := &discordgo.MessageCreate{Message: &discordgo.Message{
 		ID: "msg-date-1", ChannelID: "ch-1", Content: "昨天午餐 180",
@@ -216,7 +217,7 @@ func TestIntegration_SpecificDate_PassedToRecord(t *testing.T) {
 	loader := &mockCategoryLoader{categories: []CategoryInfo{
 		{ID: "cat-food", Name: "飲食", Type: "expense"},
 	}}
-	h := NewHandler(parser, creator, loader, nil, string(LangZhTW))
+	h := NewHandler(context.Background(), parser, creator, loader, nil, string(LangZhTW))
 
 	msg := &discordgo.MessageCreate{Message: &discordgo.Message{
 		ID: "msg-date-2", ChannelID: "ch-1", Content: "4/3 午餐 180",
@@ -258,7 +259,7 @@ func TestIntegration_DefaultTodayDate(t *testing.T) {
 	loader := &mockCategoryLoader{categories: []CategoryInfo{
 		{ID: "cat-food", Name: "飲食", Type: "expense"},
 	}}
-	h := NewHandler(parser, creator, loader, nil, string(LangZhTW))
+	h := NewHandler(context.Background(), parser, creator, loader, nil, string(LangZhTW))
 
 	msg := &discordgo.MessageCreate{Message: &discordgo.Message{
 		ID: "msg-date-3", ChannelID: "ch-1", Content: "午餐 180",
@@ -302,7 +303,7 @@ func TestIntegration_SelectMenuToConfirmFlow(t *testing.T) {
 	acctLoader := &mockAccountLoader{accounts: []AccountInfo{
 		{ID: "cc-uuid-1", Name: "中信 Visa *1234", Type: "credit_card"},
 	}}
-	h := NewHandler(parser, creator, loader, acctLoader, string(LangZhTW))
+	h := NewHandler(context.Background(), parser, creator, loader, acctLoader, string(LangZhTW))
 
 	msg := &discordgo.MessageCreate{Message: &discordgo.Message{
 		ID: "msg-select-1", ChannelID: "ch-1", Content: "午餐 180",
@@ -399,7 +400,7 @@ func TestIntegration_KnownSourceType_StillAsksAccountID(t *testing.T) {
 	acctLoader := &mockAccountLoader{accounts: []AccountInfo{
 		{ID: "cc-uuid-1", Name: "中信 Visa *1234", Type: "credit_card"},
 	}}
-	h := NewHandler(parser, creator, loader, acctLoader, string(LangZhTW))
+	h := NewHandler(context.Background(), parser, creator, loader, acctLoader, string(LangZhTW))
 
 	msg := &discordgo.MessageCreate{Message: &discordgo.Message{
 		ID: "msg-known-1", ChannelID: "ch-1", Content: "刷卡買衣服 2000",
@@ -462,7 +463,7 @@ func TestIntegration_CCPayment_FullFlow(t *testing.T) {
 		"credit_card":  {{ID: "cc-uuid-1", Name: "中信 Visa *1234", Type: "credit_card"}},
 		"bank_account": {{ID: "bank-uuid-1", Name: "中信銀行 *5678", Type: "bank_account"}},
 	}}
-	h := NewHandler(parser, creator, loader, acctLoader, string(LangZhTW), WithCCPaymentCreator(ccCreator))
+	h := NewHandler(context.Background(), parser, creator, loader, acctLoader, string(LangZhTW), WithCCPaymentCreator(ccCreator))
 
 	msg := &discordgo.MessageCreate{Message: &discordgo.Message{
 		ID: "msg-cc-1", ChannelID: "ch-1", Content: "繳中信卡 15000",
@@ -563,7 +564,7 @@ func TestIntegration_CCPayment_CancelFlow(t *testing.T) {
 		"credit_card":  {{ID: "cc-uuid-1", Name: "中信 Visa *1234", Type: "credit_card"}},
 		"bank_account": {{ID: "bank-uuid-1", Name: "中信銀行 *5678", Type: "bank_account"}},
 	}}
-	h := NewHandler(parser, creator, loader, acctLoader, string(LangZhTW), WithCCPaymentCreator(ccCreator))
+	h := NewHandler(context.Background(), parser, creator, loader, acctLoader, string(LangZhTW), WithCCPaymentCreator(ccCreator))
 
 	msg := &discordgo.MessageCreate{Message: &discordgo.Message{
 		ID: "msg-cc-2", ChannelID: "ch-1", Content: "繳中信卡 15000",
@@ -638,7 +639,7 @@ func TestIntegration_CCPayment_FullPayment_AutoAmount(t *testing.T) {
 		"credit_card":  {{ID: "cc-uuid-1", Name: "中信 Visa *1234", Type: "credit_card"}},
 		"bank_account": {{ID: "bank-uuid-1", Name: "中信銀行 *5678", Type: "bank_account"}},
 	}}
-	h := NewHandler(parser, creator, loader, acctLoader, string(LangZhTW), WithCCPaymentCreator(ccCreator))
+	h := NewHandler(context.Background(), parser, creator, loader, acctLoader, string(LangZhTW), WithCCPaymentCreator(ccCreator))
 
 	msg := &discordgo.MessageCreate{Message: &discordgo.Message{
 		ID: "msg-cc-3", ChannelID: "ch-1", Content: "繳清中信卡",
@@ -713,7 +714,7 @@ func TestIntegration_ChatGreeting(t *testing.T) {
 	parser := &mockParser{result: &ParseResult{Action: "chat", IsBookkeeping: false}}
 	creator := &mockCashFlowCreator{}
 	loader := &mockCategoryLoader{categories: []CategoryInfo{{ID: "cat-food", Name: "飲食", Type: "expense"}}}
-	h := NewHandler(parser, creator, loader, nil, string(LangZhTW))
+	h := NewHandler(context.Background(), parser, creator, loader, nil, string(LangZhTW))
 
 	msg := &discordgo.MessageCreate{Message: &discordgo.Message{
 		ID: "msg-chat-1", ChannelID: "ch-1", Content: "你好",
@@ -732,7 +733,7 @@ func TestIntegration_UnsupportedAction(t *testing.T) {
 	parser := &mockParser{result: &ParseResult{Action: "unsupported", IsBookkeeping: false}}
 	creator := &mockCashFlowCreator{}
 	loader := &mockCategoryLoader{categories: []CategoryInfo{{ID: "cat-food", Name: "飲食", Type: "expense"}}}
-	h := NewHandler(parser, creator, loader, nil, string(LangZhTW))
+	h := NewHandler(context.Background(), parser, creator, loader, nil, string(LangZhTW))
 
 	msg := &discordgo.MessageCreate{Message: &discordgo.Message{
 		ID: "msg-unsupported-1", ChannelID: "ch-1", Content: "幫我做不支援的事",
@@ -767,7 +768,7 @@ func TestQueryFlow_EndToEnd(t *testing.T) {
 		TopCategories: []CategoryBreakdown{{Name: "飲食", Amount: 5000}, {Name: "交通", Amount: 3000}},
 	}}
 	acctQuerier := &mockAccountBalanceQuerier{result: &AccountBalancesResult{}}
-	h := NewHandler(parser, creator, loader, nil, string(LangZhTW), WithCashFlowQuerier(cfQuerier), WithAccountBalanceQuerier(acctQuerier))
+	h := NewHandler(context.Background(), parser, creator, loader, nil, string(LangZhTW), WithCashFlowQuerier(cfQuerier), WithAccountBalanceQuerier(acctQuerier))
 
 	msg := &discordgo.MessageCreate{Message: &discordgo.Message{
 		ID: "msg-query-1", ChannelID: "ch-1", Content: "本月支出摘要",

--- a/backend/internal/discord/parser.go
+++ b/backend/internal/discord/parser.go
@@ -157,7 +157,7 @@ Rules:
 - Set "is_bookkeeping" to false for greetings, chit-chat, or messages that are not bookkeeping.
 - For "action":
   - If the message contains a specific amount and is recording a transaction, use "create".
-  - If the message is asking a question about spending, balance, or summary (interrogative form, no specific amount to record), use "query".
+  - If the message is asking about spending, balance, summary, or checking account/card status (e.g., 餘額, 額度, 花了多少, balance, how much), use "query". This includes phrases with a specific bank or card name like "富邦信用卡餘額" or "中信卡額度".
   - If the message is about paying a credit card bill (繳卡費/繳信用卡/pay credit card bill), use "cc_payment".
   - If the message has a clear action intent but is NOT bookkeeping, querying, or credit card payment (e.g., buying stocks, setting budgets), use "unsupported".
   - If the message is a greeting, chat, or casual conversation (嗨/你好/hello/thanks/謝謝), use "chat".
@@ -182,7 +182,7 @@ Rules:
 - If required bookkeeping information is missing for a transaction, keep "is_bookkeeping" true and list missing keys in "missing_fields".
 - For "query_type":
   - Use "cash_flow_summary" for spending, income, or cash-flow questions.
-  - Use "account_balance" for bank balance or credit card limit questions.
+  - Use "account_balance" for bank balance, credit card balance, credit card limit, credit card remaining, or any inquiry about how much is left on a card. Examples: 餘額多少, 信用卡餘額, 富邦信用卡額度, credit card balance, what's my balance.
   - Otherwise use an empty string.
 - For "query_params":
   - Resolve month/year from relative terms such as 這個月=current, 上個月=previous, last month=previous.
@@ -209,11 +209,14 @@ func defaultGeminiGenerateContent(ctx context.Context, apiKey, modelName, prompt
 
 	resp, err := model.GenerateContent(ctx, genai.Text(prompt))
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("GenerateContent error: %w", err)
 	}
 
 	text := extractTextFromResponse(resp)
 	if strings.TrimSpace(text) == "" {
+		if resp != nil && len(resp.Candidates) > 0 && resp.Candidates[0].FinishReason > 0 {
+			return "", fmt.Errorf("empty Gemini response (finish_reason=%d)", resp.Candidates[0].FinishReason)
+		}
 		return "", errors.New("empty Gemini response")
 	}
 


### PR DESCRIPTION
## Summary
- 新增 `createdAt` 欄位追蹤 pending entry 建立時間
- 實作背景清除 goroutine：每 5 分鐘掃描，清除超過 15 分鐘的過期項目
- `NewHandler` 新增 `context.Context` 參數，支援優雅關閉
- 所有 pending entry 建立點皆設定 `createdAt`，更新時保留原始時間戳

## Test plan
- [x] 新增測試：過期 entry 被清除
- [x] 新增測試：未過期 entry 保留
- [x] 新增測試：多個過期 entry 一次清除
- [x] 新增測試：context 取消後 goroutine 停止
- [x] 所有既有 Discord bot 測試通過（含 -race）

Closes #13