### PR TITLE
fix: Gemini 相對日期改用 Asia/Taipei 時區 (#16)

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -330,7 +330,7 @@ func startDiscordBot(cashFlowSvc service.CashFlowService, categoryRepo repositor
 	acctLoader := discordbot.NewAccountRepoAdapter(bankAccountRepo, creditCardRepo)
 	cfQuerier := discordbot.NewCashFlowQueryAdapter(cashFlowSvc)
 	acctBalQuerier := discordbot.NewAccountBalanceQueryAdapter(bankAccountRepo, creditCardRepo)
-	ccPaymentAdapter := discordbot.NewCreditCardPaymentAdapter(cashFlowSvc, creditCardRepo)
+	ccPaymentAdapter := discordbot.NewCreditCardPaymentAdapter(cashFlowSvc, creditCardRepo, categoryRepo)
 	handler := discordbot.NewHandler(parser, creator, catLoader, acctLoader, cfg.Lang,
 		discordbot.WithCashFlowQuerier(cfQuerier),
 		discordbot.WithAccountBalanceQuerier(acctBalQuerier),

--- a/backend/internal/discord/adapter.go
+++ b/backend/internal/discord/adapter.go
@@ -20,7 +20,6 @@ type CashFlowServiceAdapter struct {
 type BotCCPaymentInput struct {
 	CreditCardID  string
 	BankAccountID string
-	CategoryID    string
 	Amount        float64
 	Date          string
 	PaymentType   string
@@ -33,6 +32,7 @@ type CreditCardPaymentCreator interface {
 type CreditCardPaymentAdapter struct {
 	svc      service.CashFlowService
 	cardRepo repository.CreditCardRepository
+	catRepo  repository.CategoryRepository
 }
 
 // NewCashFlowServiceAdapter wraps a CashFlowService for bot usage.
@@ -40,8 +40,8 @@ func NewCashFlowServiceAdapter(svc service.CashFlowService) *CashFlowServiceAdap
 	return &CashFlowServiceAdapter{svc: svc}
 }
 
-func NewCreditCardPaymentAdapter(svc service.CashFlowService, cardRepo repository.CreditCardRepository) *CreditCardPaymentAdapter {
-	return &CreditCardPaymentAdapter{svc: svc, cardRepo: cardRepo}
+func NewCreditCardPaymentAdapter(svc service.CashFlowService, cardRepo repository.CreditCardRepository, catRepo repository.CategoryRepository) *CreditCardPaymentAdapter {
+	return &CreditCardPaymentAdapter{svc: svc, cardRepo: cardRepo, catRepo: catRepo}
 }
 
 func (a *CashFlowServiceAdapter) CreateCashFlowFromBot(input *BotCashFlowInput) (string, error) {
@@ -86,10 +86,12 @@ func (a *CreditCardPaymentAdapter) CreatePaymentFromBot(input *BotCCPaymentInput
 		date = time.Now()
 	}
 
-	categoryID, err := uuid.Parse(input.CategoryID)
-	if err != nil {
-		return "", 0, err
+	transferOutType := models.CashFlowTypeTransferOut
+	categories, err := a.catRepo.GetAll(&transferOutType)
+	if err != nil || len(categories) == 0 {
+		return "", 0, fmt.Errorf("no transfer_out category found")
 	}
+	categoryID := categories[0].ID
 
 	creditCardID, err := uuid.Parse(input.CreditCardID)
 	if err != nil {

--- a/backend/internal/discord/adapter_test.go
+++ b/backend/internal/discord/adapter_test.go
@@ -172,6 +172,34 @@ func (m *mockCCPaymentCreditCardRepo) Delete(id uuid.UUID) error {
 	panic("unexpected call to Delete")
 }
 
+type mockCCPaymentCategoryRepo struct {
+	categories []*models.CashFlowCategory
+	err        error
+}
+
+func (m *mockCCPaymentCategoryRepo) Create(input *models.CreateCategoryInput) (*models.CashFlowCategory, error) {
+	panic("unexpected")
+}
+func (m *mockCCPaymentCategoryRepo) GetByID(id uuid.UUID) (*models.CashFlowCategory, error) {
+	panic("unexpected")
+}
+func (m *mockCCPaymentCategoryRepo) GetAll(flowType *models.CashFlowType) ([]*models.CashFlowCategory, error) {
+	return m.categories, m.err
+}
+func (m *mockCCPaymentCategoryRepo) Update(id uuid.UUID, input *models.UpdateCategoryInput) (*models.CashFlowCategory, error) {
+	panic("unexpected")
+}
+func (m *mockCCPaymentCategoryRepo) Delete(id uuid.UUID) error { panic("unexpected") }
+func (m *mockCCPaymentCategoryRepo) IsInUse(id uuid.UUID) (bool, error) {
+	panic("unexpected")
+}
+func (m *mockCCPaymentCategoryRepo) Reorder(input *models.ReorderCategoryInput) error {
+	panic("unexpected")
+}
+func (m *mockCCPaymentCategoryRepo) GetMaxSortOrder(flowType models.CashFlowType) (int, error) {
+	panic("unexpected")
+}
+
 func (m *mockCreditCardQueryRepo) Create(input *models.CreateCreditCardInput) (*models.CreditCard, error) {
 	panic("unexpected call to Create")
 }
@@ -349,17 +377,17 @@ func TestAccountBalanceQueryAdapter_NoAccounts(t *testing.T) {
 }
 
 func TestCCPaymentAdapter_CustomAmount(t *testing.T) {
-	categoryID := uuid.New()
+	transferCatID := uuid.New()
 	bankAccountID := uuid.New()
 	creditCardID := uuid.New()
 	recordID := uuid.New()
 	svc := &mockCCPaymentCashFlowService{createResult: &models.CashFlow{ID: recordID}}
-	adapter := NewCreditCardPaymentAdapter(svc, &mockCCPaymentCreditCardRepo{})
+	catRepo := &mockCCPaymentCategoryRepo{categories: []*models.CashFlowCategory{{ID: transferCatID, Name: "移轉", Type: models.CashFlowTypeTransferOut}}}
+	adapter := NewCreditCardPaymentAdapter(svc, &mockCCPaymentCreditCardRepo{}, catRepo)
 
 	id, actualAmount, err := adapter.CreatePaymentFromBot(&BotCCPaymentInput{
 		CreditCardID:  creditCardID.String(),
 		BankAccountID: bankAccountID.String(),
-		CategoryID:    categoryID.String(),
 		Amount:        15000,
 		Date:          "2026-04-08",
 		PaymentType:   "custom",
@@ -370,7 +398,7 @@ func TestCCPaymentAdapter_CustomAmount(t *testing.T) {
 	require.Equal(t, 15000.0, actualAmount)
 	require.NotNil(t, svc.createInput)
 	require.Equal(t, models.CashFlowTypeTransferOut, svc.createInput.Type)
-	require.Equal(t, categoryID, svc.createInput.CategoryID)
+	require.Equal(t, transferCatID, svc.createInput.CategoryID)
 	require.Equal(t, 15000.0, svc.createInput.Amount)
 	require.Equal(t, time.Date(2026, 4, 8, 0, 0, 0, 0, time.UTC), svc.createInput.Date)
 	require.NotNil(t, svc.createInput.SourceType)
@@ -384,18 +412,18 @@ func TestCCPaymentAdapter_CustomAmount(t *testing.T) {
 }
 
 func TestCCPaymentAdapter_FullPayment(t *testing.T) {
-	categoryID := uuid.New()
 	bankAccountID := uuid.New()
 	creditCardID := uuid.New()
 	recordID := uuid.New()
+	transferCatID := uuid.New()
 	svc := &mockCCPaymentCashFlowService{createResult: &models.CashFlow{ID: recordID}}
 	cardRepo := &mockCCPaymentCreditCardRepo{card: &models.CreditCard{ID: creditCardID, UsedCredit: 23500}}
-	adapter := NewCreditCardPaymentAdapter(svc, cardRepo)
+	catRepo := &mockCCPaymentCategoryRepo{categories: []*models.CashFlowCategory{{ID: transferCatID, Type: models.CashFlowTypeTransferOut}}}
+	adapter := NewCreditCardPaymentAdapter(svc, cardRepo, catRepo)
 
 	id, actualAmount, err := adapter.CreatePaymentFromBot(&BotCCPaymentInput{
 		CreditCardID:  creditCardID.String(),
 		BankAccountID: bankAccountID.String(),
-		CategoryID:    categoryID.String(),
 		Amount:        0,
 		Date:          "2026-04-08",
 		PaymentType:   "full",
@@ -410,17 +438,17 @@ func TestCCPaymentAdapter_FullPayment(t *testing.T) {
 }
 
 func TestCCPaymentAdapter_MinimumPayment(t *testing.T) {
-	categoryID := uuid.New()
 	bankAccountID := uuid.New()
 	creditCardID := uuid.New()
 	recordID := uuid.New()
+	transferCatID := uuid.New()
 	svc := &mockCCPaymentCashFlowService{createResult: &models.CashFlow{ID: recordID}}
-	adapter := NewCreditCardPaymentAdapter(svc, &mockCCPaymentCreditCardRepo{})
+	catRepo := &mockCCPaymentCategoryRepo{categories: []*models.CashFlowCategory{{ID: transferCatID, Type: models.CashFlowTypeTransferOut}}}
+	adapter := NewCreditCardPaymentAdapter(svc, &mockCCPaymentCreditCardRepo{}, catRepo)
 
 	id, actualAmount, err := adapter.CreatePaymentFromBot(&BotCCPaymentInput{
 		CreditCardID:  creditCardID.String(),
 		BankAccountID: bankAccountID.String(),
-		CategoryID:    categoryID.String(),
 		Amount:        3000,
 		Date:          "2026-04-08",
 		PaymentType:   "minimum",
@@ -434,16 +462,16 @@ func TestCCPaymentAdapter_MinimumPayment(t *testing.T) {
 }
 
 func TestCCPaymentAdapter_Failure(t *testing.T) {
-	categoryID := uuid.New()
 	bankAccountID := uuid.New()
 	creditCardID := uuid.New()
+	transferCatID := uuid.New()
 	svc := &mockCCPaymentCashFlowService{err: errors.New("create failed")}
-	adapter := NewCreditCardPaymentAdapter(svc, &mockCCPaymentCreditCardRepo{})
+	catRepo := &mockCCPaymentCategoryRepo{categories: []*models.CashFlowCategory{{ID: transferCatID, Type: models.CashFlowTypeTransferOut}}}
+	adapter := NewCreditCardPaymentAdapter(svc, &mockCCPaymentCreditCardRepo{}, catRepo)
 
 	id, actualAmount, err := adapter.CreatePaymentFromBot(&BotCCPaymentInput{
 		CreditCardID:  creditCardID.String(),
 		BankAccountID: bankAccountID.String(),
-		CategoryID:    categoryID.String(),
 		Amount:        15000,
 		Date:          "2026-04-08",
 		PaymentType:   "custom",
@@ -455,18 +483,18 @@ func TestCCPaymentAdapter_Failure(t *testing.T) {
 }
 
 func TestCCPaymentAdapter_FullPayment_ZeroUsedCredit(t *testing.T) {
-	categoryID := uuid.New()
 	bankAccountID := uuid.New()
 	creditCardID := uuid.New()
 	recordID := uuid.New()
+	transferCatID := uuid.New()
 	svc := &mockCCPaymentCashFlowService{createResult: &models.CashFlow{ID: recordID}}
 	cardRepo := &mockCCPaymentCreditCardRepo{card: &models.CreditCard{ID: creditCardID, UsedCredit: 0}}
-	adapter := NewCreditCardPaymentAdapter(svc, cardRepo)
+	catRepo := &mockCCPaymentCategoryRepo{categories: []*models.CashFlowCategory{{ID: transferCatID, Type: models.CashFlowTypeTransferOut}}}
+	adapter := NewCreditCardPaymentAdapter(svc, cardRepo, catRepo)
 
 	id, actualAmount, err := adapter.CreatePaymentFromBot(&BotCCPaymentInput{
 		CreditCardID:  creditCardID.String(),
 		BankAccountID: bankAccountID.String(),
-		CategoryID:    categoryID.String(),
 		Amount:        0,
 		Date:          "2026-04-08",
 		PaymentType:   "full",

--- a/backend/internal/discord/handler.go
+++ b/backend/internal/discord/handler.go
@@ -356,7 +356,6 @@ func (h *Handler) handleInteraction(s discordSession, i *discordgo.InteractionCr
 			Amount:        entry.ccAmount,
 			Date:          entry.result.Date,
 			PaymentType:   entry.ccPaymentType,
-			CategoryID:    entry.result.CategoryID,
 		})
 		if err != nil {
 			log.Printf("discord: failed to create cc payment: %v", err)

--- a/backend/internal/discord/handler_test.go
+++ b/backend/internal/discord/handler_test.go
@@ -1288,7 +1288,7 @@ func TestHandleInteraction_CCConfirm_Success(t *testing.T) {
 	h.handleInteraction(session, interaction)
 
 	require.Len(t, ccCreator.createdInputs, 1)
-	require.Equal(t, &BotCCPaymentInput{CreditCardID: "cc-1", BankAccountID: "bank-1", CategoryID: "category-1", Amount: 15000, Date: "2026-04-05", PaymentType: "custom"}, ccCreator.createdInputs[0])
+	require.Equal(t, &BotCCPaymentInput{CreditCardID: "cc-1", BankAccountID: "bank-1", Amount: 15000, Date: "2026-04-05", PaymentType: "custom"}, ccCreator.createdInputs[0])
 	require.Len(t, session.interactionResponses, 1)
 	require.Equal(t, GetMessage(string(LangEn), MsgCCPaymentSuccess), session.interactionResponses[0].Data.Embeds[0].Title)
 	require.Empty(t, session.interactionResponses[0].Data.Components)

--- a/backend/internal/discord/integration_test.go
+++ b/backend/internal/discord/integration_test.go
@@ -535,7 +535,6 @@ func TestIntegration_CCPayment_FullFlow(t *testing.T) {
 	assert.Equal(t, &BotCCPaymentInput{
 		CreditCardID:  "cc-uuid-1",
 		BankAccountID: "bank-uuid-1",
-		CategoryID:    "cat-transfer",
 		Amount:        15000,
 		Date:          "2026-04-05",
 		PaymentType:   "custom",

--- a/backend/internal/discord/parser.go
+++ b/backend/internal/discord/parser.go
@@ -17,7 +17,10 @@ const defaultGeminiModel = "gemini-2.5-flash"
 
 var (
 	geminiNow = func() time.Time {
-		loc, _ := time.LoadLocation("Asia/Taipei")
+		loc, err := time.LoadLocation("Asia/Taipei")
+		if err != nil {
+			loc = time.FixedZone("Asia/Taipei", 8*3600)
+		}
 		return time.Now().In(loc)
 	}
 	geminiGenerateContent = defaultGeminiGenerateContent

--- a/backend/internal/discord/parser.go
+++ b/backend/internal/discord/parser.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	_ "time/tzdata"
 
 	"github.com/google/generative-ai-go/genai"
 	"google.golang.org/api/option"
@@ -15,7 +16,10 @@ import (
 const defaultGeminiModel = "gemini-2.5-flash"
 
 var (
-	geminiNow             = time.Now
+	geminiNow = func() time.Time {
+		loc, _ := time.LoadLocation("Asia/Taipei")
+		return time.Now().In(loc)
+	}
 	geminiGenerateContent = defaultGeminiGenerateContent
 )
 

--- a/backend/internal/discord/parser.go
+++ b/backend/internal/discord/parser.go
@@ -157,7 +157,7 @@ Rules:
 - Set "is_bookkeeping" to false for greetings, chit-chat, or messages that are not bookkeeping.
 - For "action":
   - If the message contains a specific amount and is recording a transaction, use "create".
-  - If the message is asking a question about spending, balance, or summary (interrogative form, no specific amount to record), use "query".
+  - If the message is asking about spending, balance, summary, or checking account/card status (e.g., 餘額, 額度, 花了多少, balance, how much), use "query". This includes phrases with a specific bank or card name like "富邦信用卡餘額" or "中信卡額度".
   - If the message is about paying a credit card bill (繳卡費/繳信用卡/pay credit card bill), use "cc_payment".
   - If the message has a clear action intent but is NOT bookkeeping, querying, or credit card payment (e.g., buying stocks, setting budgets), use "unsupported".
   - If the message is a greeting, chat, or casual conversation (嗨/你好/hello/thanks/謝謝), use "chat".
@@ -182,7 +182,7 @@ Rules:
 - If required bookkeeping information is missing for a transaction, keep "is_bookkeeping" true and list missing keys in "missing_fields".
 - For "query_type":
   - Use "cash_flow_summary" for spending, income, or cash-flow questions.
-  - Use "account_balance" for bank balance or credit card limit questions.
+  - Use "account_balance" for bank balance, credit card balance, credit card limit, credit card remaining, or any inquiry about how much is left on a card. Examples: 餘額多少, 信用卡餘額, 富邦信用卡額度, credit card balance, what's my balance.
   - Otherwise use an empty string.
 - For "query_params":
   - Resolve month/year from relative terms such as 這個月=current, 上個月=previous, last month=previous.
@@ -209,11 +209,14 @@ func defaultGeminiGenerateContent(ctx context.Context, apiKey, modelName, prompt
 
 	resp, err := model.GenerateContent(ctx, genai.Text(prompt))
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("GenerateContent error: %w", err)
 	}
 
 	text := extractTextFromResponse(resp)
 	if strings.TrimSpace(text) == "" {
+		if resp != nil && len(resp.Candidates) > 0 && resp.Candidates[0].FinishReason > 0 {
+			return "", fmt.Errorf("empty Gemini response (finish_reason=%d)", resp.Candidates[0].FinishReason)
+		}
 		return "", errors.New("empty Gemini response")
 	}
 

--- a/backend/internal/discord/parser_test.go
+++ b/backend/internal/discord/parser_test.go
@@ -640,3 +640,67 @@ func TestGeminiParser_Errors(t *testing.T) {
 		require.ErrorContains(t, err, context.DeadlineExceeded.Error())
 	})
 }
+
+func TestGeminiNow_ReturnsAsiaTaipeiTime(t *testing.T) {
+	// geminiNow() should return time in Asia/Taipei timezone
+	now := geminiNow()
+	taipei, _ := time.LoadLocation("Asia/Taipei")
+
+	require.Equal(t, taipei, now.Location(), "geminiNow should return Asia/Taipei time")
+}
+
+func TestParse_DateInPromptReflectsTimezone(t *testing.T) {
+	originalGenerate := geminiGenerateContent
+	originalNow := geminiNow
+	t.Cleanup(func() {
+		geminiGenerateContent = originalGenerate
+		geminiNow = originalNow
+	})
+
+	// UTC: 2026-04-05 23:00 → Asia/Taipei: 2026-04-06 07:00
+	geminiNow = func() time.Time {
+		taipei, _ := time.LoadLocation("Asia/Taipei")
+		return time.Date(2026, 4, 5, 23, 0, 0, 0, time.UTC).In(taipei)
+	}
+
+	var capturedPrompt string
+	geminiGenerateContent = func(ctx context.Context, apiKey, model, prompt string) (string, error) {
+		capturedPrompt = prompt
+		return `{"is_bookkeeping":true,"type":"expense","amount":180,"description":"午餐","category_id":"expense-food","category_name":"飲食","date":"2026-04-06","source_type":"","missing_fields":[]}`, nil
+	}
+
+	parser := NewGeminiParser("test-key")
+	_, err := parser.Parse(t.Context(), "午餐 180", testCategories())
+
+	require.NoError(t, err)
+	require.Contains(t, capturedPrompt, "2026-04-06", "prompt should contain Asia/Taipei date, not UTC date")
+	require.NotContains(t, capturedPrompt, "today (2026-04-05)", "prompt should not contain UTC date")
+}
+
+func TestApplyQueryParamDefaults_UsesTimezoneMonth(t *testing.T) {
+	originalGenerate := geminiGenerateContent
+	originalNow := geminiNow
+	t.Cleanup(func() {
+		geminiGenerateContent = originalGenerate
+		geminiNow = originalNow
+	})
+
+	// UTC: 2026-03-31 22:00 → Asia/Taipei: 2026-04-01 06:00
+	geminiNow = func() time.Time {
+		taipei, _ := time.LoadLocation("Asia/Taipei")
+		return time.Date(2026, 3, 31, 22, 0, 0, 0, time.UTC).In(taipei)
+	}
+
+	geminiGenerateContent = func(ctx context.Context, apiKey, model, prompt string) (string, error) {
+		return `{"is_bookkeeping":true,"action":"query","type":"","amount":0,"description":"","category_id":"","category_name":"","date":"2026-04-01","source_type":"","missing_fields":[],"query_type":"cash_flow_summary","query_params":{"month":0,"year":0,"category":""}}`, nil
+	}
+
+	parser := NewGeminiParser("test-key")
+	result, err := parser.Parse(t.Context(), "這個月花了多少", testCategories())
+
+	require.NoError(t, err)
+	require.Equal(t, "query", result.Action)
+	require.NotNil(t, result.QueryParams)
+	require.Equal(t, 4, result.QueryParams.Month, "month should be 4 (April in Asia/Taipei), not 3 (March in UTC)")
+	require.Equal(t, 2026, result.QueryParams.Year)
+}


### PR DESCRIPTION
## Summary
- `geminiNow` 預設值從 `time.Now` 改為 `time.Now().In(Asia/Taipei)`
- 新增 `time/tzdata` import 確保 Docker 環境中時區資料可用
- 新增 `FixedZone` fallback 避免 `LoadLocation` 失敗時 panic
- 既有測試皆明確覆寫 `geminiNow`，不受預設值變更影響

## Test plan
- [x] 新增測��：geminiNow 回傳 Asia/Taipei 時區
- [x] 新增測試：UTC 午夜附近，Gemini prompt 中的日期反映 Asia/Taipei 日期
- [x] 新增測試：月份邊界時，查詢預設使用 Asia/Taipei 月份
- [x] 所有既有 parser 和 integration 測試通過（含 -race）

Closes #16