### PR TITLE
feat(frontend): 新增前端測試覆蓋率 — TanStack Query hooks 單元測試

### DIFF
--- a/frontend/src/hooks/useAnalytics.test.ts
+++ b/frontend/src/hooks/useAnalytics.test.ts
@@ -1,0 +1,135 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { http, HttpResponse } from "msw";
+import { server } from "@/test/server";
+import { useAnalyticsSummary } from "./useAnalytics";
+import type { ReactNode } from "react";
+
+const API_BASE = "http://localhost:8080";
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return ({ children }: { children: ReactNode }) =>
+    QueryClientProvider({ client: queryClient, children });
+}
+
+describe("useAnalyticsSummary", () => {
+  it("returns loading state initially", () => {
+    const { result } = renderHook(() => useAnalyticsSummary(), {
+      wrapper: createWrapper(),
+    });
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("returns data on success", async () => {
+    server.use(
+      http.get(`${API_BASE}/api/analytics/summary`, () => {
+        return HttpResponse.json({
+          data: {
+            total_realized_pl: 15000,
+            total_realized_pl_pct: 5.2,
+            total_cost_basis: 288000,
+            total_sell_amount: 303000,
+            total_sell_fee: 400,
+            transaction_count: 12,
+            currency: "TWD",
+            time_range: "month",
+            start_date: "2025-10-01",
+            end_date: "2025-10-31",
+          },
+        });
+      })
+    );
+
+    const { result } = renderHook(() => useAnalyticsSummary(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBeDefined();
+    expect(result.current.data!.total_realized_pl).toBe(15000);
+    expect(result.current.data!.transaction_count).toBe(12);
+  });
+
+  it("returns error on API failure", async () => {
+    server.use(
+      http.get(`${API_BASE}/api/analytics/summary`, () => {
+        return HttpResponse.json(
+          { data: null, error: { code: "INTERNAL_ERROR", message: "fail" } },
+          { status: 500 }
+        );
+      })
+    );
+
+    const { result } = renderHook(() => useAnalyticsSummary(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toBeDefined();
+    expect(result.current.error!.code).toBe("HTTP_ERROR");
+  });
+
+  it("passes time_range as query param", async () => {
+    let capturedUrl = "";
+    server.use(
+      http.get(`${API_BASE}/api/analytics/summary`, ({ request }) => {
+        capturedUrl = request.url;
+        return HttpResponse.json({
+          data: {
+            total_realized_pl: 0,
+            total_realized_pl_pct: 0,
+            total_cost_basis: 0,
+            total_sell_amount: 0,
+            total_sell_fee: 0,
+            transaction_count: 0,
+            currency: "TWD",
+            time_range: "year",
+            start_date: "2025-01-01",
+            end_date: "2025-12-31",
+          },
+        });
+      })
+    );
+
+    const { result } = renderHook(() => useAnalyticsSummary("year"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(capturedUrl).toContain("time_range=year");
+  });
+
+  it("defaults to month time range", async () => {
+    let capturedUrl = "";
+    server.use(
+      http.get(`${API_BASE}/api/analytics/summary`, ({ request }) => {
+        capturedUrl = request.url;
+        return HttpResponse.json({
+          data: {
+            total_realized_pl: 0,
+            total_realized_pl_pct: 0,
+            total_cost_basis: 0,
+            total_sell_amount: 0,
+            total_sell_fee: 0,
+            transaction_count: 0,
+            currency: "TWD",
+            time_range: "month",
+            start_date: "2025-10-01",
+            end_date: "2025-10-31",
+          },
+        });
+      })
+    );
+
+    const { result } = renderHook(() => useAnalyticsSummary(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(capturedUrl).toContain("time_range=month");
+  });
+});

--- a/frontend/src/hooks/useBankAccounts.test.ts
+++ b/frontend/src/hooks/useBankAccounts.test.ts
@@ -1,0 +1,95 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { http, HttpResponse } from "msw";
+import { server } from "@/test/server";
+import { useBankAccounts } from "./useBankAccounts";
+import type { ReactNode } from "react";
+
+const API_BASE = "http://localhost:8080";
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return ({ children }: { children: ReactNode }) =>
+    QueryClientProvider({ client: queryClient, children });
+}
+
+describe("useBankAccounts", () => {
+  it("returns loading state initially", () => {
+    const { result } = renderHook(() => useBankAccounts(), {
+      wrapper: createWrapper(),
+    });
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("returns data on success", async () => {
+    server.use(
+      http.get(`${API_BASE}/api/bank-accounts`, () => {
+        return HttpResponse.json({
+          data: [
+            {
+              id: "ba-1",
+              bank_name: "台北富邦銀行",
+              account_type: "savings",
+              account_number_last4: "1234",
+              currency: "TWD",
+              balance: 150000,
+              note: null,
+              created_at: "2025-01-01T00:00:00Z",
+              updated_at: "2025-01-01T00:00:00Z",
+            },
+          ],
+        });
+      })
+    );
+
+    const { result } = renderHook(() => useBankAccounts(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.data![0].id).toBe("ba-1");
+    expect(result.current.data![0].bank_name).toBe("台北富邦銀行");
+    expect(result.current.data![0].balance).toBe(150000);
+  });
+
+  it("returns error on API failure", async () => {
+    server.use(
+      http.get(`${API_BASE}/api/bank-accounts`, () => {
+        return HttpResponse.json(
+          { data: null, error: { code: "INTERNAL_ERROR", message: "fail" } },
+          { status: 500 }
+        );
+      })
+    );
+
+    const { result } = renderHook(() => useBankAccounts(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toBeDefined();
+    expect(result.current.error!.code).toBe("HTTP_ERROR");
+  });
+
+  it("passes filters as query params", async () => {
+    let capturedUrl = "";
+    server.use(
+      http.get(`${API_BASE}/api/bank-accounts`, ({ request }) => {
+        capturedUrl = request.url;
+        return HttpResponse.json({ data: [] });
+      })
+    );
+
+    const { result } = renderHook(
+      () => useBankAccounts({ currency: "USD" }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(capturedUrl).toContain("currency=USD");
+  });
+});

--- a/frontend/src/hooks/useCashFlows.test.ts
+++ b/frontend/src/hooks/useCashFlows.test.ts
@@ -1,0 +1,100 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { http, HttpResponse } from "msw";
+import { server } from "@/test/server";
+import { useCashFlows } from "./useCashFlows";
+import type { ReactNode } from "react";
+
+const API_BASE = "http://localhost:8080";
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return ({ children }: { children: ReactNode }) =>
+    QueryClientProvider({ client: queryClient, children });
+}
+
+describe("useCashFlows", () => {
+  it("returns loading state initially", () => {
+    const { result } = renderHook(() => useCashFlows(), {
+      wrapper: createWrapper(),
+    });
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("returns data on success", async () => {
+    server.use(
+      http.get(`${API_BASE}/api/cash-flows`, () => {
+        return HttpResponse.json({
+          data: [
+            {
+              id: "cf-1",
+              date: "2025-10-25",
+              type: "income",
+              category_id: "cat-1",
+              amount: 50000,
+              currency: "TWD",
+              description: "十月薪資",
+              note: null,
+              source_type: null,
+              source_id: null,
+              target_type: null,
+              target_id: null,
+              created_at: "2025-10-25T00:00:00Z",
+              updated_at: "2025-10-25T00:00:00Z",
+            },
+          ],
+        });
+      })
+    );
+
+    const { result } = renderHook(() => useCashFlows(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.data![0].id).toBe("cf-1");
+    expect(result.current.data![0].amount).toBe(50000);
+  });
+
+  it("returns error on API failure", async () => {
+    server.use(
+      http.get(`${API_BASE}/api/cash-flows`, () => {
+        return HttpResponse.json(
+          { data: null, error: { code: "INTERNAL_ERROR", message: "fail" } },
+          { status: 500 }
+        );
+      })
+    );
+
+    const { result } = renderHook(() => useCashFlows(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toBeDefined();
+    expect(result.current.error!.code).toBe("HTTP_ERROR");
+  });
+
+  it("passes filters as query params", async () => {
+    let capturedUrl = "";
+    server.use(
+      http.get(`${API_BASE}/api/cash-flows`, ({ request }) => {
+        capturedUrl = request.url;
+        return HttpResponse.json({ data: [] });
+      })
+    );
+
+    const { result } = renderHook(
+      () => useCashFlows({ type: "expense", limit: 10 }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(capturedUrl).toContain("type=expense");
+    expect(capturedUrl).toContain("limit=10");
+  });
+});

--- a/frontend/src/hooks/useHoldings.test.ts
+++ b/frontend/src/hooks/useHoldings.test.ts
@@ -1,0 +1,125 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { http, HttpResponse } from "msw";
+import { server } from "@/test/server";
+import { useHoldings } from "./useHoldings";
+import type { ReactNode } from "react";
+
+const API_BASE = "http://localhost:8080";
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return ({ children }: { children: ReactNode }) =>
+    QueryClientProvider({ client: queryClient, children });
+}
+
+describe("useHoldings", () => {
+  it("returns loading state initially", () => {
+    const { result } = renderHook(() => useHoldings(), {
+      wrapper: createWrapper(),
+    });
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("returns data on success", async () => {
+    server.use(
+      http.get(`${API_BASE}/api/holdings`, () => {
+        return HttpResponse.json({
+          data: [
+            {
+              symbol: "2330",
+              name: "台積電",
+              asset_type: "tw-stock",
+              quantity: 10,
+              avg_cost: 550,
+              avg_cost_original: 550,
+              total_cost: 5500,
+              current_price: 600,
+              currency: "TWD",
+              current_price_twd: 600,
+              market_value: 6000,
+              unrealized_pl: 500,
+              unrealized_pl_pct: 9.09,
+            },
+          ],
+          warnings: [],
+        });
+      })
+    );
+
+    const { result } = renderHook(() => useHoldings(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBeDefined();
+    expect(result.current.data!.data).toHaveLength(1);
+    expect(result.current.data!.data[0].symbol).toBe("2330");
+    expect(result.current.data!.warnings).toEqual([]);
+  });
+
+  it("returns warnings when present", async () => {
+    server.use(
+      http.get(`${API_BASE}/api/holdings`, () => {
+        return HttpResponse.json({
+          data: [],
+          warnings: [
+            {
+              code: "PRICE_STALE",
+              symbol: "2330",
+              message: "Price data is stale",
+            },
+          ],
+        });
+      })
+    );
+
+    const { result } = renderHook(() => useHoldings(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data!.warnings).toHaveLength(1);
+    expect(result.current.data!.warnings[0].code).toBe("PRICE_STALE");
+  });
+
+  it("returns error on API failure", async () => {
+    server.use(
+      http.get(`${API_BASE}/api/holdings`, () => {
+        return HttpResponse.json(
+          { data: null, error: { code: "INTERNAL_ERROR", message: "fail" } },
+          { status: 500 }
+        );
+      })
+    );
+
+    const { result } = renderHook(() => useHoldings(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toBeDefined();
+    expect(result.current.error!.code).toBe("HTTP_ERROR");
+  });
+
+  it("passes filters as query params", async () => {
+    let capturedUrl = "";
+    server.use(
+      http.get(`${API_BASE}/api/holdings`, ({ request }) => {
+        capturedUrl = request.url;
+        return HttpResponse.json({ data: [], warnings: [] });
+      })
+    );
+
+    const { result } = renderHook(
+      () => useHoldings({ asset_type: "tw-stock" }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(capturedUrl).toContain("asset_type=tw-stock");
+  });
+});

--- a/frontend/src/hooks/useSubscriptions.test.ts
+++ b/frontend/src/hooks/useSubscriptions.test.ts
@@ -1,0 +1,101 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { http, HttpResponse } from "msw";
+import { server } from "@/test/server";
+import { useSubscriptions } from "./useSubscriptions";
+import type { ReactNode } from "react";
+
+const API_BASE = "http://localhost:8080";
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return ({ children }: { children: ReactNode }) =>
+    QueryClientProvider({ client: queryClient, children });
+}
+
+describe("useSubscriptions", () => {
+  it("returns loading state initially", () => {
+    const { result } = renderHook(() => useSubscriptions(), {
+      wrapper: createWrapper(),
+    });
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("returns data on success", async () => {
+    server.use(
+      http.get(`${API_BASE}/api/subscriptions`, () => {
+        return HttpResponse.json({
+          data: [
+            {
+              id: "sub-1",
+              name: "Netflix",
+              amount: 390,
+              currency: "TWD",
+              billing_cycle: "monthly",
+              billing_day: 15,
+              category_id: "cat-1",
+              payment_method: "credit_card",
+              account_id: "card-1",
+              start_date: "2025-01-15",
+              auto_renew: true,
+              status: "active",
+              created_at: "2025-01-15T00:00:00Z",
+              updated_at: "2025-01-15T00:00:00Z",
+            },
+          ],
+        });
+      })
+    );
+
+    const { result } = renderHook(() => useSubscriptions(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.data![0].id).toBe("sub-1");
+    expect(result.current.data![0].name).toBe("Netflix");
+    expect(result.current.data![0].status).toBe("active");
+  });
+
+  it("returns error on API failure", async () => {
+    server.use(
+      http.get(`${API_BASE}/api/subscriptions`, () => {
+        return HttpResponse.json(
+          { data: null, error: { code: "INTERNAL_ERROR", message: "fail" } },
+          { status: 500 }
+        );
+      })
+    );
+
+    const { result } = renderHook(() => useSubscriptions(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toBeDefined();
+    expect(result.current.error!.code).toBe("HTTP_ERROR");
+  });
+
+  it("passes filters as query params", async () => {
+    let capturedUrl = "";
+    server.use(
+      http.get(`${API_BASE}/api/subscriptions`, ({ request }) => {
+        capturedUrl = request.url;
+        return HttpResponse.json({ data: [] });
+      })
+    );
+
+    const { result } = renderHook(
+      () => useSubscriptions({ status: "active", limit: 10 }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(capturedUrl).toContain("status=active");
+    expect(capturedUrl).toContain("limit=10");
+  });
+});

--- a/frontend/src/hooks/useTransactions.test.ts
+++ b/frontend/src/hooks/useTransactions.test.ts
@@ -1,0 +1,102 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { http, HttpResponse } from "msw";
+import { server } from "@/test/server";
+import { useTransactions } from "./useTransactions";
+import type { ReactNode } from "react";
+
+const API_BASE = "http://localhost:8080";
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return ({ children }: { children: ReactNode }) =>
+    QueryClientProvider({ client: queryClient, children });
+}
+
+describe("useTransactions", () => {
+  it("returns loading state initially", () => {
+    const { result } = renderHook(() => useTransactions(), {
+      wrapper: createWrapper(),
+    });
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("returns data on success", async () => {
+    server.use(
+      http.get(`${API_BASE}/api/transactions`, () => {
+        return HttpResponse.json({
+          data: [
+            {
+              id: "txn-1",
+              date: "2025-10-23T00:00:00Z",
+              asset_type: "tw-stock",
+              symbol: "2330",
+              name: "台積電",
+              type: "buy",
+              quantity: 10,
+              price: 620,
+              amount: 6200,
+              fee: 20,
+              tax: null,
+              currency: "TWD",
+              exchange_rate_id: null,
+              note: null,
+              created_at: "2025-10-23T00:00:00Z",
+              updated_at: "2025-10-23T00:00:00Z",
+            },
+          ],
+        });
+      })
+    );
+
+    const { result } = renderHook(() => useTransactions(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.data![0].id).toBe("txn-1");
+    expect(result.current.data![0].symbol).toBe("2330");
+  });
+
+  it("returns error on API failure", async () => {
+    server.use(
+      http.get(`${API_BASE}/api/transactions`, () => {
+        return HttpResponse.json(
+          { data: null, error: { code: "INTERNAL_ERROR", message: "fail" } },
+          { status: 500 }
+        );
+      })
+    );
+
+    const { result } = renderHook(() => useTransactions(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toBeDefined();
+    expect(result.current.error!.code).toBe("HTTP_ERROR");
+  });
+
+  it("passes filters as query params", async () => {
+    let capturedUrl = "";
+    server.use(
+      http.get(`${API_BASE}/api/transactions`, ({ request }) => {
+        capturedUrl = request.url;
+        return HttpResponse.json({ data: [] });
+      })
+    );
+
+    const { result } = renderHook(
+      () => useTransactions({ asset_type: "us-stock", limit: 5 }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(capturedUrl).toContain("asset_type=us-stock");
+    expect(capturedUrl).toContain("limit=5");
+  });
+});

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -9,6 +9,12 @@ export default defineConfig({
     globals: true,
     setupFiles: ["./src/test/setup.ts"],
     include: ["src/**/*.test.{ts,tsx}"],
+    pool: "forks",
+    poolOptions: {
+      forks: {
+        execArgv: ["--experimental-require-module"],
+      },
+    },
     coverage: {
       provider: "v8",
       reportsDirectory: "./coverage",


### PR DESCRIPTION
## 摘要

建立前端測試基礎架構（Vitest + React Testing Library + MSW），並為 6 個 TanStack Query hooks 撰寫共 26 個單元測試，涵蓋 loading、success、error 狀態。

Closes #17

## 動機

前端目前零測試檔案，後端有 67 個測試檔案約 21,000 行測試碼。此 PR 建立前端測試架構並優先針對核心 data-fetching hooks 撰寫測試，填補專案最大的測試缺口。

## 實作方式

- 使用 Vitest 3.x + jsdom 環境，搭配 `@vitejs/plugin-react` 處理 JSX
- MSW (Mock Service Worker) 在 network 層攔截 API 請求，測試更貼近實際行為
- 共用測試工具：`renderWithProviders` 包裝 QueryClientProvider + NextIntlClientProvider
- 測試檔案與原始碼 co-locate（`useHoldings.test.ts` 在 `useHoldings.ts` 旁邊）
- 加入 `pool: "forks"` 和 `--experimental-require-module` 修復 jsdom 29 ESM 相容性問題

## 變更內容

- `frontend/vitest.config.ts` — 新增 pool forks 設定
- `frontend/src/hooks/useHoldings.test.ts` — 5 個測試（loading、success、warnings、error、filters）
- `frontend/src/hooks/useTransactions.test.ts` — 4 個測試
- `frontend/src/hooks/useCashFlows.test.ts` — 4 個測試
- `frontend/src/hooks/useAnalytics.test.ts` — 5 個測試（含 time_range 參數驗證）
- `frontend/src/hooks/useSubscriptions.test.ts` — 4 個測試
- `frontend/src/hooks/useBankAccounts.test.ts` — 4 個測試

## 測試計畫

- [x] `pnpm test` 通過 — 6 個測試檔案、26 個測試全部通過
- [ ] 確認 hook 的 loading → success 狀態轉換正常
- [ ] 確認 API 500 錯誤能正確轉為 isError 狀態
- [ ] 確認現有 `pnpm build` 不受影響