### PR TITLE
fix(reconciliation): lock account row with FOR UPDATE during reconcile

### DIFF
--- a/backend/internal/service/reconciliation_service.go
+++ b/backend/internal/service/reconciliation_service.go
@@ -112,7 +112,8 @@ func (s *reconciliationService) reconcileCreditCardTx(
 	)
 	err := tx.QueryRow(
 		`SELECT used_credit, credit_limit, issuing_bank, card_name, card_number_last4
-		 FROM credit_cards WHERE id = $1`,
+		 FROM credit_cards WHERE id = $1
+		 FOR UPDATE`,
 		id,
 	).Scan(&currUsed, &currLimit, &issuingBank, &cardName, &last4)
 	if err == sql.ErrNoRows {
@@ -247,7 +248,8 @@ func (s *reconciliationService) reconcileBankAccountTx(
 		last4          string
 	)
 	err := tx.QueryRow(
-		`SELECT balance, bank_name, account_number_last4 FROM bank_accounts WHERE id = $1`,
+		`SELECT balance, bank_name, account_number_last4 FROM bank_accounts WHERE id = $1
+		 FOR UPDATE`,
 		id,
 	).Scan(&currentBalance, &bankName, &last4)
 	if err == sql.ErrNoRows {

--- a/backend/internal/service/reconciliation_service_test.go
+++ b/backend/internal/service/reconciliation_service_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -336,6 +337,59 @@ func TestReconcileBatch_OneItemFails_RollsBackAll(t *testing.T) {
 	gotC, err := env.cardRepo.GetByID(c.ID)
 	require.NoError(t, err)
 	assert.Equal(t, 5000.0, gotC.UsedCredit)
+}
+
+func TestReconcileBankAccount_ConcurrentReconcile_CashFlowMatchesFinalDelta(t *testing.T) {
+	env := newReconciliationTestEnv(t)
+	defer env.db.Close()
+
+	startBalance := 1000.0
+	acc := seedBankAccount(t, env, startBalance)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	errs := make([]error, 2)
+	targets := []float64{1500, 1200}
+	for i, target := range targets {
+		i, target := i, target
+		go func() {
+			defer wg.Done()
+			_, errs[i] = env.svc.ReconcileBankAccount(acc.ID, &models.ReconcileBankAccountInput{
+				NewBalance: target,
+				Date:       time.Now(),
+			})
+		}()
+	}
+	wg.Wait()
+	for _, err := range errs {
+		require.NoError(t, err)
+	}
+
+	updated, err := env.bankRepo.GetByID(acc.ID)
+	require.NoError(t, err)
+
+	var totalDelta float64
+	rows, err := env.db.Query(
+		`SELECT type, amount FROM cash_flows
+		 WHERE source_type = $1 AND source_id = $2`,
+		models.SourceTypeBankAccount, acc.ID,
+	)
+	require.NoError(t, err)
+	defer rows.Close()
+	for rows.Next() {
+		var typ string
+		var amt float64
+		require.NoError(t, rows.Scan(&typ, &amt))
+		if typ == string(models.CashFlowTypeIncome) {
+			totalDelta += amt
+		} else {
+			totalDelta -= amt
+		}
+	}
+	require.NoError(t, rows.Err())
+
+	assert.InDelta(t, updated.Balance-startBalance, totalDelta, 0.001,
+		"sum of cash_flow deltas must equal final balance - starting balance")
 }
 
 func TestReconcileBankAccount_NegativeBalance(t *testing.T) {


### PR DESCRIPTION
## Summary

並發 reconcile 同一帳戶時，原本初始 SELECT 不持鎖會讓兩個 tx 都讀到同一份起始 balance，造成 cash_flow 雙重入帳。改用 `SELECT ... FOR UPDATE` 後第二個 tx 會等到第一個 commit/rollback 才讀，自然算出正確的 delta。

Closes #57

## Changes

- `backend/internal/service/reconciliation_service.go`: 兩個 `reconcile*Tx` helper 的初始 SELECT 加上 `FOR UPDATE`。
- `backend/internal/service/reconciliation_service_test.go`: 新增 `TestReconcileBankAccount_ConcurrentReconcile_CashFlowMatchesFinalDelta`，兩個 goroutine 並發 reconcile 同一帳戶，驗證所有 cash_flow 的 delta 總和等於 final balance - start balance。

## Test plan

- [x] `go test -run TestReconcile -count=1 ./internal/service/...`
- [ ] 手動觸發兩個 concurrent reconcile（透過 user-management 頁面）