### PR TITLE
fix(reconciliation): use bank account currency for adjustment cash flow

### DIFF
--- a/backend/internal/service/reconciliation_service.go
+++ b/backend/internal/service/reconciliation_service.go
@@ -174,6 +174,7 @@ func (s *reconciliationService) reconcileCreditCardTx(
 		 (date, type, category_id, amount, currency, description, note, source_type, source_id)
 		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 		 RETURNING id`,
+		// TODO: credit_cards 目前無 currency 欄位，先沿用 TWD；新增欄位後改讀卡片自身 currency。
 		input.Date, flowType, categoryID, amount, models.CurrencyTWD,
 		description, input.Note, srcType, srcID,
 	).Scan(&newID)
@@ -246,12 +247,13 @@ func (s *reconciliationService) reconcileBankAccountTx(
 		currentBalance float64
 		bankName       string
 		last4          string
+		currency       string
 	)
 	err := tx.QueryRow(
-		`SELECT balance, bank_name, account_number_last4 FROM bank_accounts WHERE id = $1
+		`SELECT balance, bank_name, account_number_last4, currency FROM bank_accounts WHERE id = $1
 		 FOR UPDATE`,
 		id,
-	).Scan(&currentBalance, &bankName, &last4)
+	).Scan(&currentBalance, &bankName, &last4, &currency)
 	if err == sql.ErrNoRows {
 		return nil, fmt.Errorf("bank account not found")
 	}
@@ -297,7 +299,7 @@ func (s *reconciliationService) reconcileBankAccountTx(
 		 (date, type, category_id, amount, currency, description, note, source_type, source_id)
 		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 		 RETURNING id`,
-		input.Date, flowType, categoryID, amount, models.CurrencyTWD,
+		input.Date, flowType, categoryID, amount, currency,
 		description, input.Note, srcType, srcID,
 	).Scan(&newID)
 	if err != nil {

--- a/backend/internal/service/reconciliation_service_test.go
+++ b/backend/internal/service/reconciliation_service_test.go
@@ -339,6 +339,31 @@ func TestReconcileBatch_OneItemFails_RollsBackAll(t *testing.T) {
 	assert.Equal(t, 5000.0, gotC.UsedCredit)
 }
 
+func TestReconcileBankAccount_NonTWD_CashFlowUsesAccountCurrency(t *testing.T) {
+	env := newReconciliationTestEnv(t)
+	defer env.db.Close()
+
+	acc, err := env.bankRepo.Create(&models.CreateBankAccountInput{
+		BankName:           "玉山",
+		AccountType:        "活存",
+		AccountNumberLast4: "9999",
+		Currency:           models.CurrencyUSD,
+		Balance:            1000,
+	})
+	require.NoError(t, err)
+
+	res, err := env.svc.ReconcileBankAccount(acc.ID, &models.ReconcileBankAccountInput{
+		NewBalance: 1500,
+		Date:       time.Now(),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res.CashFlowID)
+
+	cf, err := env.cfRepo.GetByID(*res.CashFlowID)
+	require.NoError(t, err)
+	assert.Equal(t, models.CurrencyUSD, cf.Currency)
+}
+
 func TestReconcileBankAccount_ConcurrentReconcile_CashFlowMatchesFinalDelta(t *testing.T) {
 	env := newReconciliationTestEnv(t)
 	defer env.db.Close()

--- a/backend/migrations/000030_relax_cash_flows_currency_check.down.sql
+++ b/backend/migrations/000030_relax_cash_flows_currency_check.down.sql
@@ -1,0 +1,5 @@
+-- 還原為僅允許 TWD。
+-- 警告：執行前必須確保現有資料不存在 USD 列，否則會失敗。
+ALTER TABLE cash_flows DROP CONSTRAINT IF EXISTS cash_flows_currency_check;
+ALTER TABLE cash_flows ADD CONSTRAINT cash_flows_currency_check
+    CHECK (currency = 'TWD');

--- a/backend/migrations/000030_relax_cash_flows_currency_check.up.sql
+++ b/backend/migrations/000030_relax_cash_flows_currency_check.up.sql
@@ -1,0 +1,5 @@
+-- 放寬 cash_flows.currency 限制，允許 TWD 與 USD。
+-- 動機：bank_accounts 已支援 USD；reconciliation 產生的調整 cash flow 應沿用帳戶幣別。
+ALTER TABLE cash_flows DROP CONSTRAINT IF EXISTS cash_flows_currency_check;
+ALTER TABLE cash_flows ADD CONSTRAINT cash_flows_currency_check
+    CHECK (currency IN ('TWD', 'USD'));


### PR DESCRIPTION
## Summary

之前寫死 `models.CurrencyTWD` 會在 USD 帳戶上產生幣別不一致的 adjustment cash flow，且原本 `cash_flows.currency` 有 `CHECK (currency = 'TWD')` 阻擋寫入 USD 列 — 那才是寫死 TWD 的真正原因。本 PR 兩處同步修正。

Closes #55

> Stacked on top of #58 (issues/57)。請先 merge #58 後此 PR 的 base 會自動切回 \`dev\`。

## Changes

- `backend/migrations/000030_relax_cash_flows_currency_check.{up,down}.sql`: 將 `cash_flows_currency_check` 由 \`= 'TWD'\` 放寬為 \`IN ('TWD', 'USD')\`。
- `backend/internal/service/reconciliation_service.go`: bank account 的初始 SELECT 補撈 `currency`，cash flow INSERT 沿用該值。credit_cards 目前無 currency 欄位，留 TODO 暫沿用 TWD。
- `backend/internal/service/reconciliation_service_test.go`: 新增 `TestReconcileBankAccount_NonTWD_CashFlowUsesAccountCurrency`，驗證 USD 帳戶會產出 \`Currency = USD\` 的 cash flow。

## Test plan

- [x] `make migrate-test-up-env` 套用 migration 000030
- [x] `go test -run TestReconcile -count=1 ./internal/service/...`
- [ ] 手動建立 USD 帳戶並觸發 reconcile，確認 cash flow currency 正確