### PR TITLE
refactor(reconciliation): map service errors to 400/404/500 by type

### DIFF
--- a/backend/internal/api/reconciliation_handler.go
+++ b/backend/internal/api/reconciliation_handler.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/chienchuanw/asset-manager/internal/models"
@@ -8,6 +9,25 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 )
+
+// mapReconcileError 將 service 層 sentinel errors 映射成 HTTP status / API code。
+func mapReconcileError(err error) (int, string) {
+	switch {
+	case errors.Is(err, service.ErrBankAccountNotFound),
+		errors.Is(err, service.ErrCreditCardNotFound):
+		return http.StatusNotFound, "NOT_FOUND"
+	case errors.Is(err, service.ErrInvalidInput),
+		errors.Is(err, service.ErrUsedExceedsLimit):
+		return http.StatusBadRequest, "INVALID_INPUT"
+	default:
+		return http.StatusInternalServerError, "RECONCILE_FAILED"
+	}
+}
+
+func writeReconcileError(c *gin.Context, err error) {
+	status, code := mapReconcileError(err)
+	c.JSON(status, APIResponse{Error: &APIError{Code: code, Message: err.Error()}})
+}
 
 // ReconciliationHandler 校準 API
 type ReconciliationHandler struct {
@@ -29,6 +49,7 @@ func NewReconciliationHandler(svc service.ReconciliationService) *Reconciliation
 // @Param input body models.ReconcileBankAccountInput true "校準資料"
 // @Success 200 {object} APIResponse{data=models.ReconcileResult}
 // @Failure 400 {object} APIResponse{error=APIError}
+// @Failure 404 {object} APIResponse{error=APIError}
 // @Failure 500 {object} APIResponse{error=APIError}
 // @Router /api/bank-accounts/{id}/reconcile [post]
 func (h *ReconciliationHandler) ReconcileBankAccount(c *gin.Context) {
@@ -48,9 +69,7 @@ func (h *ReconciliationHandler) ReconcileBankAccount(c *gin.Context) {
 	}
 	res, err := h.service.ReconcileBankAccount(id, &input)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, APIResponse{Error: &APIError{
-			Code: "RECONCILE_FAILED", Message: err.Error(),
-		}})
+		writeReconcileError(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, APIResponse{Data: res})
@@ -66,6 +85,7 @@ func (h *ReconciliationHandler) ReconcileBankAccount(c *gin.Context) {
 // @Param input body models.ReconcileCreditCardInput true "校準資料"
 // @Success 200 {object} APIResponse{data=models.ReconcileResult}
 // @Failure 400 {object} APIResponse{error=APIError}
+// @Failure 404 {object} APIResponse{error=APIError}
 // @Failure 500 {object} APIResponse{error=APIError}
 // @Router /api/credit-cards/{id}/reconcile [post]
 func (h *ReconciliationHandler) ReconcileCreditCard(c *gin.Context) {
@@ -85,9 +105,7 @@ func (h *ReconciliationHandler) ReconcileCreditCard(c *gin.Context) {
 	}
 	res, err := h.service.ReconcileCreditCard(id, &input)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, APIResponse{Error: &APIError{
-			Code: "RECONCILE_FAILED", Message: err.Error(),
-		}})
+		writeReconcileError(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, APIResponse{Data: res})
@@ -102,6 +120,7 @@ func (h *ReconciliationHandler) ReconcileCreditCard(c *gin.Context) {
 // @Param input body models.ReconcileBatchInput true "批次校準資料"
 // @Success 200 {object} APIResponse{data=[]models.ReconcileResult}
 // @Failure 400 {object} APIResponse{error=APIError}
+// @Failure 404 {object} APIResponse{error=APIError}
 // @Failure 500 {object} APIResponse{error=APIError}
 // @Router /api/user-management/reconcile-batch [post]
 func (h *ReconciliationHandler) ReconcileBatch(c *gin.Context) {
@@ -114,9 +133,7 @@ func (h *ReconciliationHandler) ReconcileBatch(c *gin.Context) {
 	}
 	res, err := h.service.ReconcileBatch(&input)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, APIResponse{Error: &APIError{
-			Code: "RECONCILE_FAILED", Message: err.Error(),
-		}})
+		writeReconcileError(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, APIResponse{Data: res})

--- a/backend/internal/api/reconciliation_handler_test.go
+++ b/backend/internal/api/reconciliation_handler_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/chienchuanw/asset-manager/internal/models"
+	"github.com/chienchuanw/asset-manager/internal/service"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -92,6 +93,66 @@ func TestReconcileBankAccountHandler_ServiceError(t *testing.T) {
 	w := httptest.NewRecorder()
 	setupReconciliationRouter(svc).ServeHTTP(w, req)
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestReconcileBankAccountHandler_NotFoundMapsTo404(t *testing.T) {
+	svc := &mockReconciliationService{}
+	id := uuid.New()
+	svc.On("ReconcileBankAccount", id, mock.Anything).Return(nil, service.ErrBankAccountNotFound)
+
+	body, _ := json.Marshal(models.ReconcileBankAccountInput{NewBalance: 1, Date: time.Now()})
+	req := httptest.NewRequest("POST", "/api/bank-accounts/"+id.String()+"/reconcile", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	setupReconciliationRouter(svc).ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestReconcileCreditCardHandler_NotFoundMapsTo404(t *testing.T) {
+	svc := &mockReconciliationService{}
+	id := uuid.New()
+	used := 1.0
+	svc.On("ReconcileCreditCard", id, mock.Anything).Return(nil, service.ErrCreditCardNotFound)
+
+	body, _ := json.Marshal(models.ReconcileCreditCardInput{NewUsedCredit: &used, Date: time.Now()})
+	req := httptest.NewRequest("POST", "/api/credit-cards/"+id.String()+"/reconcile", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	setupReconciliationRouter(svc).ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestReconcileCreditCardHandler_UsedExceedsLimitMapsTo400(t *testing.T) {
+	svc := &mockReconciliationService{}
+	id := uuid.New()
+	used := 99999.0
+	svc.On("ReconcileCreditCard", id, mock.Anything).Return(nil, service.ErrUsedExceedsLimit)
+
+	body, _ := json.Marshal(models.ReconcileCreditCardInput{NewUsedCredit: &used, Date: time.Now()})
+	req := httptest.NewRequest("POST", "/api/credit-cards/"+id.String()+"/reconcile", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	setupReconciliationRouter(svc).ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestReconcileBatchHandler_InvalidInputMapsTo400(t *testing.T) {
+	svc := &mockReconciliationService{}
+	bal := 1.0
+	id := uuid.New()
+	svc.On("ReconcileBatch", mock.Anything).Return(nil, service.ErrInvalidInput)
+
+	body, _ := json.Marshal(models.ReconcileBatchInput{
+		Date: time.Now(),
+		Items: []models.ReconcileBatchItem{
+			{TargetType: models.SourceTypeBankAccount, TargetID: id, NewBalance: &bal},
+		},
+	})
+	req := httptest.NewRequest("POST", "/api/user-management/reconcile-batch", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	setupReconciliationRouter(svc).ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
 func TestReconcileCreditCardHandler_Success(t *testing.T) {

--- a/backend/internal/service/reconciliation_service.go
+++ b/backend/internal/service/reconciliation_service.go
@@ -2,11 +2,20 @@ package service
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 
 	"github.com/chienchuanw/asset-manager/internal/models"
 	"github.com/chienchuanw/asset-manager/internal/repository"
 	"github.com/google/uuid"
+)
+
+// Sentinel errors so handlers can map to HTTP status codes via errors.Is.
+var (
+	ErrBankAccountNotFound = errors.New("bank account not found")
+	ErrCreditCardNotFound  = errors.New("credit card not found")
+	ErrUsedExceedsLimit    = errors.New("used_credit exceeds credit_limit")
+	ErrInvalidInput        = errors.New("invalid input")
 )
 
 // ReconciliationService 校準操作業務邏輯
@@ -47,7 +56,7 @@ func (s *reconciliationService) loadAdjustmentCategories() (*adjustmentCategoryI
 // ReconcileBankAccount 校準銀行帳戶餘額
 func (s *reconciliationService) ReconcileBankAccount(id uuid.UUID, input *models.ReconcileBankAccountInput) (*models.ReconcileResult, error) {
 	if err := input.Validate(); err != nil {
-		return nil, fmt.Errorf("invalid input: %w", err)
+		return nil, fmt.Errorf("%w: %s", ErrInvalidInput, err.Error())
 	}
 	cats, err := s.loadAdjustmentCategories()
 	if err != nil {
@@ -73,7 +82,7 @@ func (s *reconciliationService) ReconcileBankAccount(id uuid.UUID, input *models
 // ReconcileCreditCard 校準信用卡 used_credit / credit_limit
 func (s *reconciliationService) ReconcileCreditCard(id uuid.UUID, input *models.ReconcileCreditCardInput) (*models.ReconcileResult, error) {
 	if err := input.Validate(); err != nil {
-		return nil, fmt.Errorf("invalid input: %w", err)
+		return nil, fmt.Errorf("%w: %s", ErrInvalidInput, err.Error())
 	}
 	cats, err := s.loadAdjustmentCategories()
 	if err != nil {
@@ -117,7 +126,7 @@ func (s *reconciliationService) reconcileCreditCardTx(
 		id,
 	).Scan(&currUsed, &currLimit, &issuingBank, &cardName, &last4)
 	if err == sql.ErrNoRows {
-		return nil, fmt.Errorf("credit card not found")
+		return nil, ErrCreditCardNotFound
 	}
 	if err != nil {
 		return nil, fmt.Errorf("fetch credit card: %w", err)
@@ -132,7 +141,7 @@ func (s *reconciliationService) reconcileCreditCardTx(
 		nextLimit = *input.NewCreditLimit
 	}
 	if nextUsed > nextLimit {
-		return nil, fmt.Errorf("used_credit (%v) cannot exceed credit_limit (%v)", nextUsed, nextLimit)
+		return nil, fmt.Errorf("%w: used_credit (%v) cannot exceed credit_limit (%v)", ErrUsedExceedsLimit, nextUsed, nextLimit)
 	}
 
 	if _, err := tx.Exec(
@@ -188,7 +197,7 @@ func (s *reconciliationService) reconcileCreditCardTx(
 // ReconcileBatch 批次校準（共用單一 transaction）
 func (s *reconciliationService) ReconcileBatch(input *models.ReconcileBatchInput) ([]*models.ReconcileResult, error) {
 	if err := input.Validate(); err != nil {
-		return nil, fmt.Errorf("invalid input: %w", err)
+		return nil, fmt.Errorf("%w: %s", ErrInvalidInput, err.Error())
 	}
 	cats, err := s.loadAdjustmentCategories()
 	if err != nil {
@@ -226,7 +235,7 @@ func (s *reconciliationService) ReconcileBatch(input *models.ReconcileBatchInput
 			}
 			results = append(results, r)
 		default:
-			return nil, fmt.Errorf("items[%d]: unsupported target_type %s", i, item.TargetType)
+			return nil, fmt.Errorf("items[%d]: %w: unsupported target_type %s", i, ErrInvalidInput, item.TargetType)
 		}
 	}
 
@@ -255,7 +264,7 @@ func (s *reconciliationService) reconcileBankAccountTx(
 		id,
 	).Scan(&currentBalance, &bankName, &last4, &currency)
 	if err == sql.ErrNoRows {
-		return nil, fmt.Errorf("bank account not found")
+		return nil, ErrBankAccountNotFound
 	}
 	if err != nil {
 		return nil, fmt.Errorf("fetch bank account: %w", err)


### PR DESCRIPTION
## Summary

`ReconciliationHandler` 之前把 service 層所有錯誤映射為 \`500 RECONCILE_FAILED\`，導致 not-found 與 input validation 都看不出差別。改為依錯誤種類分流到 400 / 404 / 500。

Closes #56

> Stacked on top of #59 (issues/55) → #58 (issues/57)。

## Changes

### Backend service
- `backend/internal/service/reconciliation_service.go`: 新增 sentinel errors \`ErrBankAccountNotFound\` / \`ErrCreditCardNotFound\` / \`ErrUsedExceedsLimit\` / \`ErrInvalidInput\`，原 \`fmt.Errorf\` 改用 \`%w\` 包裝。

### Backend handler
- `backend/internal/api/reconciliation_handler.go`: 新增 \`mapReconcileError(err) (status, code)\` 與 \`writeReconcileError(c, err)\` helper，三個 endpoint 統一呼叫。
  - not-found → 404 / \`NOT_FOUND\`
  - invalid input / used > limit → 400 / \`INVALID_INPUT\`
  - 其他 → 500 / \`RECONCILE_FAILED\`

### Tests
- `backend/internal/api/reconciliation_handler_test.go`: 新增 4 個 case 覆蓋每條 sentinel 路徑（bank/credit not found、used>limit、batch invalid input）。

## Test plan

- [x] \`go test -count=1 ./internal/api/... ./internal/service/...\`
- [ ] 手動觸發 not-found / used>limit 案例，確認前端 toast 顯示 message 而非 generic 500