### PR TITLE
fix(holding): 修正價格抓取失敗時持倉幣別為空的問題

### DIFF
--- a/backend/internal/service/fifo_calculator.go
+++ b/backend/internal/service/fifo_calculator.go
@@ -275,6 +275,12 @@ func (c *fifoCalculator) calculateHoldingFromBatches(symbol, name string, assetT
 	avgCostTWD := totalCostTWD / totalQuantity
 	avgCostOriginal := totalCostOriginal / totalQuantity
 
+	// 幣別取自最後一個成本批次（同標的的所有批次幣別應一致）
+	var currency models.Currency
+	if len(batches) > 0 {
+		currency = batches[len(batches)-1].Currency
+	}
+
 	return &models.Holding{
 		Symbol:          symbol,
 		Name:            name,
@@ -283,6 +289,7 @@ func (c *fifoCalculator) calculateHoldingFromBatches(symbol, name string, assetT
 		AvgCost:         avgCostTWD,
 		AvgCostOriginal: avgCostOriginal,
 		TotalCost:       totalCostTWD,
+		Currency:        currency,
 		LastUpdated:     time.Now(),
 	}
 }

--- a/backend/internal/service/holding_service.go
+++ b/backend/internal/service/holding_service.go
@@ -126,6 +126,11 @@ func (s *holdingService) GetAllHoldings(filters models.HoldingFilters) (*Holding
 		log.Printf("[DEBUG] Processing holding: %s (AssetType: %s, Quantity: %.4f)",
 			symbol, holding.AssetType, holding.Quantity)
 
+		// 幣別由 asset_type 推導，與價格抓取結果無關，必須先設定
+		// 否則當價格服務失敗走入 else 分支時，currency 會是空字串
+		currency := s.getCurrencyForAssetType(holding.AssetType)
+		holding.Currency = currency
+
 		price, exists := prices[symbol]
 		if exists && price.Price > 0 {
 			log.Printf("[DEBUG] Price found for %s: %.4f (Source: %s, IsStale: %v)",
@@ -133,10 +138,6 @@ func (s *holdingService) GetAllHoldings(filters models.HoldingFilters) (*Holding
 
 			// 有價格資訊且價格有效
 			holding.CurrentPrice = price.Price
-
-			// 根據資產類型決定幣別
-			currency := s.getCurrencyForAssetType(holding.AssetType)
-			holding.Currency = currency
 			log.Printf("[DEBUG] Currency for %s: %s", symbol, currency)
 
 			// 將價格轉換為 TWD

--- a/backend/internal/service/holding_service_test.go
+++ b/backend/internal/service/holding_service_test.go
@@ -390,6 +390,65 @@ func TestGetHoldingBySymbol_Success(t *testing.T) {
 	mockPriceService.AssertExpectations(t)
 }
 
+// TestGetAllHoldings_PriceUnavailable_StillSetsCurrency 迴歸測試 issue #77：
+// 當價格服務無法取得某標的價格時，回傳的 Holding 仍須有正確 Currency，
+// 否則前端批次對帳 dialog 會顯示空白幣別且無法修正。
+func TestGetAllHoldings_PriceUnavailable_StillSetsCurrency(t *testing.T) {
+	mockRepo := new(MockTransactionRepositoryForHolding)
+	mockPriceService := new(MockPriceService)
+	mockExchangeRateService := new(MockExchangeRateService)
+	fifoCalculator := NewFIFOCalculator(mockExchangeRateService)
+	service := NewHoldingService(mockRepo, fifoCalculator, mockPriceService, mockExchangeRateService)
+
+	transactions := []*models.Transaction{
+		{
+			Date:            time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			AssetType:       models.AssetTypeUSStock,
+			Symbol:          "AAPL",
+			Name:            "Apple Inc.",
+			TransactionType: models.TransactionTypeBuy,
+			Quantity:        50,
+			Price:           150,
+			Amount:          7500,
+			Fee:             ptrFloat64(10),
+			Currency:        models.CurrencyUSD,
+		},
+		{
+			Date:            time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC),
+			AssetType:       models.AssetTypeTWStock,
+			Symbol:          "2330",
+			Name:            "台積電",
+			TransactionType: models.TransactionTypeBuy,
+			Quantity:        100,
+			Price:           500,
+			Amount:          50000,
+			Fee:             ptrFloat64(28),
+			Currency:        models.CurrencyTWD,
+		},
+	}
+
+	mockRepo.On("GetAll", mock.Anything).Return(transactions, nil)
+	mockExchangeRateService.On("ConvertToTWD", 7510.0, models.CurrencyUSD, mock.Anything).Return(225300.0, nil)
+	// 模擬價格服務完全無法取得任何標的的價格
+	mockPriceService.On("GetPrices", mock.Anything, mock.Anything).
+		Return(map[string]*models.Price{}, nil)
+
+	result, err := service.GetAllHoldings(models.HoldingFilters{})
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(result.Holdings))
+
+	for _, h := range result.Holdings {
+		assert.NotEmptyf(t, string(h.Currency), "%s holding must have currency even when price unavailable", h.Symbol)
+		switch h.AssetType {
+		case models.AssetTypeUSStock, models.AssetTypeCrypto:
+			assert.Equal(t, models.CurrencyUSD, h.Currency)
+		case models.AssetTypeTWStock:
+			assert.Equal(t, models.CurrencyTWD, h.Currency)
+		}
+	}
+}
+
 // TestGetHoldingBySymbol_NotFound 測試標的不存在
 func TestGetHoldingBySymbol_NotFound(t *testing.T) {
 	// Arrange


### PR DESCRIPTION
## 摘要

修正 `GetAllHoldings` 在價格服務失敗時回傳的持倉 `Currency` 為空字串的 bug，使前端「批次持倉對帳」dialog 不再出現空白且鎖定的幣別欄位。

Closes #77

## 根本原因

`backend/internal/service/holding_service.go` 的 `GetAllHoldings` 將 `holding.Currency` 的指派寫在「有取得價格」的分支內（第 138-139 行）；當價格服務失敗走入 else 分支（第 175-188 行）時，currency 完全沒被設定，便以空字串回傳。

進一步追溯，`backend/internal/service/fifo_calculator.go` 的 `calculateHoldingFromBatches` 建立 `Holding` 時也沒設定 `Currency`，所以該欄位完全仰賴 holding_service 的價格分支補上。

Currency 本質上是 `asset_type` 的純函式（tw-stock→TWD、us-stock/crypto→USD），不應與價格抓取耦合。

## 修復說明

- 將 `holding.Currency = s.getCurrencyForAssetType(...)` 從價格分支內提到 if/else 之前，無論價格是否可得都會設定。
- 移除價格分支內已成為重複的指派。
- 加固：在 `calculateHoldingFromBatches` 從最後一個成本批次取得 Currency，確保 FIFO 不會回傳空 currency。
- 前端 `BatchReconcileHoldingsDialog.tsx:215` 的 `disabled={r.__existing}` 維持不變 — currency 由 asset_type 推導，不應允許既有列改幣別（會破壞 FIFO 計算）。

## 變更內容

- `backend/internal/service/holding_service.go` — 將 currency 指派提到 if/else 之前
- `backend/internal/service/fifo_calculator.go` — `calculateHoldingFromBatches` 設定 Currency
- `backend/internal/service/holding_service_test.go` — 新增迴歸測試 `TestGetAllHoldings_PriceUnavailable_StillSetsCurrency`

## 測試方式

- [ ] `go test ./internal/service/ -count=1` 全部通過
- [ ] 在 `/holdings` 開啟「批次持倉對帳」，確認所有既有持倉的幣別欄位皆正確顯示（tw-stock 為 TWD，us-stock/crypto 為 USD），即使價格暫時無法取得
- [ ] 對既有持倉進行對帳預覽 / 寫入，確認流程正常

## 回歸風險

低 — 變更僅限於 currency 欄位的填入時機，不影響 FIFO 計算、價格轉換或市值計算邏輯。新增的迴歸測試涵蓋價格不可得的情境。