### PR TITLE
build: pin pnpm to 10.33.0 in frontend Dockerfile

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,7 +3,7 @@
 FROM node:20-alpine AS deps
 
 # 安裝 pnpm
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
 
 WORKDIR /app
 
@@ -17,7 +17,7 @@ RUN pnpm install --frozen-lockfile
 FROM node:20-alpine AS builder
 
 # 安裝 pnpm
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
 
 WORKDIR /app
 


### PR DESCRIPTION
Follow-up to #79. `corepack prepare pnpm@latest` now installs pnpm 11, which needs Node 22 (`node:sqlite`) and breaks the build on `node:20-alpine`. Pin to the lockfile's version (10.33.0).