### PR TITLE
security: harden frontend/backend containers with read-only fs + tmpfs noexec

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,49 @@
+# Container Security Hardening
+
+This document records the runtime security hardening applied to the Docker Compose stack after the 2026-05-08 Next.js MCP-server RCE incident (PRs #79, #80). The goal is to reduce the blast radius if any single container is compromised again.
+
+## Applied controls (docker-compose.yml)
+
+The `backend` and `frontend` services run with:
+
+| Control | Setting | Why |
+|---|---|---|
+| Read-only root filesystem | `read_only: true` | Attacker cannot drop a payload anywhere outside explicitly mounted tmpfs. |
+| Hardened `/tmp` | `tmpfs: /tmp` with `rw,noexec,nosuid,size=64m` | The XMRig dropper (`javae`, `kinsing`) needed `/tmp` writable AND executable. `noexec` blocks the launch step entirely. |
+| Frontend Next.js cache | `tmpfs: /app/.next/cache` with `rw,nosuid,size=128m` | Next.js standalone needs `.next/cache` writable for the image optimization cache. Kept separate so we don't need to make rootfs writable. |
+| Drop all capabilities | `cap_drop: [ALL]` | Neither service needs Linux capabilities at runtime. |
+| No privilege escalation | `security_opt: [no-new-privileges:true]` | Blocks setuid binaries from elevating. |
+| Process count limit | `deploy.resources.limits.pids: 200` | Caps fork-bombs and runaway miners. |
+
+The `postgres`, `redis`, `nginx`, and `certbot` services are unchanged for now — they need writable state directories (`/var/lib/postgresql/data`, `/data`, `/var/cache/nginx`, `/etc/letsencrypt`) and tightening them is a separate exercise.
+
+## Verification
+
+After `docker compose up -d`:
+
+```bash
+# Health check passes
+make health
+
+# /app is read-only inside the frontend container
+docker compose exec frontend sh -c 'touch /app/x' # expect: Read-only file system
+
+# /tmp is writable but non-executable inside the frontend container
+docker compose exec frontend sh -c 'echo \#!/bin/sh > /tmp/t && chmod +x /tmp/t && /tmp/t' # expect: Permission denied
+
+# Same checks for backend
+docker compose exec backend sh -c 'touch /x' # expect: Read-only file system
+docker compose exec backend sh -c 'echo data > /tmp/t && chmod +x /tmp/t && /tmp/t' # expect: Permission denied
+```
+
+## Why these specific values
+
+- `tmpfs size=64m` for `/tmp`: enough for legitimate temp files (sockets, lock files) but too small for the ~5–10 MB miner binaries seen in the incident plus their config and logs.
+- `pids: 200`: comfortably above normal worker counts (Next.js + Node worker threads, Gin goroutines stay as one OS process), but well below the levels a coin-miner with worker fork-out would need.
+- `/app/.next/cache size=128m`: Next.js image cache for a small SPA stays well under this. If you start serving large image catalogs and see eviction churn in logs, raise it.
+
+## Related work
+
+- Issue #82 — nginx attack surface reduction (proxy paths, rate limiting, SSRF blocks)
+- Issue #83 — dependency CVE monitoring + base image digest pinning
+- Issue #85 — intrusion and availability alerting

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,12 +106,21 @@ services:
       - "127.0.0.1:8080:8080"
     networks:
       - asset-manager-network
+    # 安全強化：限制容器爆炸半徑
+    read_only: true
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,size=64m
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
     # 資源限制 (可選,防止單一容器佔用過多資源)
     deploy:
       resources:
         limits:
           cpus: "1.0"
           memory: 512M
+          pids: 200
         reservations:
           cpus: "0.5"
           memory: 256M
@@ -134,11 +143,21 @@ services:
       - "127.0.0.1:3000:3000"
     networks:
       - asset-manager-network
+    # 安全強化：阻斷在 /tmp 落地並執行挖礦程式的攻擊路徑
+    read_only: true
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,size=64m
+      - /app/.next/cache:rw,nosuid,size=128m
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
     deploy:
       resources:
         limits:
           cpus: "0.5"
           memory: 256M
+          pids: 200
         reservations:
           cpus: "0.25"
           memory: 128M

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,6 +114,9 @@ services:
       - ALL
     security_opt:
       - no-new-privileges:true
+    # pids_limit 重複在頂層 + deploy 區塊：前者是 Compose 在 standalone (非 Swarm) 模式
+    # 下保證會套用的欄位；後者覆蓋 Swarm 路徑。兩者值必須一致。
+    pids_limit: 200
     # 資源限制 (可選,防止單一容器佔用過多資源)
     deploy:
       resources:
@@ -147,11 +150,12 @@ services:
     read_only: true
     tmpfs:
       - /tmp:rw,noexec,nosuid,size=64m
-      - /app/.next/cache:rw,nosuid,size=128m
+      - /app/.next/cache:rw,noexec,nosuid,size=128m
     cap_drop:
       - ALL
     security_opt:
       - no-new-privileges:true
+    pids_limit: 200
     deploy:
       resources:
         limits:


### PR DESCRIPTION
## Summary

Closes #81.

Reduces the blast radius of any future container compromise following the 2026-05-08 Next.js MCP RCE incident:

- `read_only: true` rootfs on `frontend` and `backend` services
- `/tmp` mounted as tmpfs with `rw,noexec,nosuid,size=64m` — directly defeats the dropper step used by the XMRig/kinsing payload
- `/app/.next/cache` tmpfs for Next.js standalone image cache (only writable surface left in the frontend)
- `cap_drop: [ALL]`, `no-new-privileges:true`, `pids: 200` under `deploy.resources.limits`

Adds `SECURITY.md` documenting the controls and verification commands.

## Test plan

- [ ] `docker compose config` passes (verified locally)
- [ ] `docker compose up -d` brings the stack up and `make health` passes
- [ ] Inside `frontend`: `touch /app/x` → `Read-only file system`
- [ ] Inside `frontend`: writing then `chmod +x` and executing a file in `/tmp` → `Permission denied`
- [ ] Same two checks pass for `backend`