### PR TITLE
security: tighten nginx attack surface (scan blocks, SSRF, rate limit)

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -38,6 +38,15 @@ http {
     # 上傳檔案大小限制
     client_max_body_size 10M;
 
+    # 限流：對動態請求做基本 rate limiting
+    # 20 r/s 平均，burst 40 — 一般使用者不會碰到，但能擋住掃描/爆破
+    limit_req_zone $binary_remote_addr zone=dynamic:10m rate=20r/s;
+    limit_req_status 429;
+    limit_conn_zone $binary_remote_addr zone=perip:10m;
+
+    # 隱藏 nginx 版本
+    server_tokens off;
+
     # Upstream 定義
     upstream backend {
         server backend:8080;
@@ -110,6 +119,42 @@ http {
             add_header Content-Type text/plain;
         }
 
+        # === 攻擊面收斂 ===
+        # 阻擋常見掃描路徑（dotfile、版控元資料、CGI、挖礦相關字串）
+        # 444 = 不回應、直接斷線，省頻寬也不給掃描器訊號
+        location ~ /\.(env|git|bash_history|aws|ssh|htaccess|htpasswd|DS_Store) {
+            access_log off;
+            return 444;
+        }
+        location ~* /cgi-bin/ {
+            access_log off;
+            return 444;
+        }
+        location ~* (xmrig|kinsing|kdevtmpfsi|c3pool|supportxmr) {
+            access_log off;
+            return 444;
+        }
+
+        # 阻擋 Next.js 16 實驗性 MCP server 路徑（即使 next.config.ts 已關閉，多一層保險）
+        location ~* ^/mcp(/|$) {
+            access_log off;
+            return 404;
+        }
+
+        # Next.js 內部端點：data/、webpack HMR 等不應對外
+        # 只允許 /_next/static 和 /_next/image（後者用獨立 location 處理）
+        location ~* ^/_next/(data|webpack-hmr|server)/ {
+            access_log off;
+            return 404;
+        }
+
+        # Next.js 圖片優化端點：本專案 images.unoptimized=true，因此直接擋掉
+        # 同時防止 SSRF（攻擊者把 url= 指向 169.254.169.254 雲端 metadata）
+        location ~* ^/_next/image {
+            access_log off;
+            return 404;
+        }
+
         # API 請求代理到 Backend
         location /api/ {
             proxy_pass http://backend;
@@ -146,6 +191,10 @@ http {
 
         # 前端其他請求
         location / {
+            # 限流：擋掃描/爆破，正常使用者遠低於此
+            limit_req zone=dynamic burst=40 nodelay;
+            limit_conn perip 20;
+
             proxy_pass http://frontend;
             proxy_http_version 1.1;
 


### PR DESCRIPTION
## Summary

Closes #82.

Reduces exposure of internal/dangerous endpoints through the public nginx proxy after the 2026-05-08 incident, where access logs showed heavy probing of `/_next/image?url=http://169.254.169.254/...` (cloud metadata SSRF), `/.env`, `/.git/config`, `/mcp`, and miner-pool JSON-RPC payloads.

### Changes (nginx.conf)

- **Rate limiting**: \`limit_req_zone 20r/s\` (burst 40), \`limit_conn 20\` per-IP on the dynamic catch-all
- **Scanner blocks** (return 444 — drop connection silently): \`/.env\`, \`/.git\`, \`/.bash_history\`, \`/cgi-bin/\`, miner-name strings (\`xmrig\`, \`kinsing\`, \`kdevtmpfsi\`)
- **/mcp/* → 404** as a defense-in-depth layer over \`experimental.mcpServer: false\` already set in \`next.config.ts\`
- **Internal Next.js endpoints → 404**: \`/_next/data/\`, \`/_next/webpack-hmr\`, \`/_next/server/\`
- **\`/_next/image\` → 404**: this project sets \`images.unoptimized: true\`, so the endpoint is unused; hard-blocking it eliminates the SSRF probe vector entirely
- **\`server_tokens off\`** to hide nginx version

\`/_next/static/\` and \`/api/\` remain proxied unchanged.

## Test plan

- [ ] \`nginx -t\` passes (verified locally with stub certs)
- [ ] After deploy: \`curl -i https://asset.chienchuanw.com/_next/image?url=http://169.254.169.254/\` returns 404
- [ ] \`curl -i https://asset.chienchuanw.com/.env\` returns 444 (empty / connection closed)
- [ ] \`curl -i https://asset.chienchuanw.com/mcp\` returns 404
- [ ] Normal page navigation and login flow still work
- [ ] Static assets under \`/_next/static/\` still load
- [ ] Rapid requests (>60/s from one IP) hit 429