### PR TITLE
security: Dependabot, audit CI, and digest-pin base images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,63 @@
+version: 2
+updates:
+  # Frontend npm dependencies (Next.js, React, etc.)
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "frontend"
+    groups:
+      next-ecosystem:
+        patterns:
+          - "next"
+          - "@next/*"
+          - "next-*"
+      react-ecosystem:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react*"
+
+  # Backend Go module dependencies
+  - package-ecosystem: "gomod"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "backend"
+
+  # Docker base images (catches the digest-pinned FROM lines)
+  - package-ecosystem: "docker"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "docker"
+
+  - package-ecosystem: "docker"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "docker"
+
+  # GitHub Actions workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "ci"

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,62 @@
+name: Security Audit
+
+# 每週一掃描相依套件漏洞；PR 觸發時也跑一次以儘早發現。
+# 全部設為 non-blocking（continue-on-error），目的是「發現」而非「阻擋合併」，
+# Dependabot 負責後續升級 PR。
+on:
+  pull_request:
+    branches: [dev, main]
+  schedule:
+    - cron: "0 3 * * 1" # 每週一 03:00 UTC（≒ 11:00 Asia/Taipei）
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  frontend-audit:
+    name: pnpm audit (frontend)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - name: pnpm install
+        run: pnpm install --frozen-lockfile
+
+      - name: pnpm audit (high+ severity)
+        run: pnpm audit --audit-level=high --prod
+        continue-on-error: true
+
+  backend-audit:
+    name: govulncheck (backend)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: backend/go.mod
+          cache-dependency-path: backend/go.sum
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      - name: Run govulncheck
+        run: govulncheck ./...
+        continue-on-error: true

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10.33.0
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,8 @@
 # 多階段建置 Dockerfile for Go Backend
 # Stage 1: 建置階段
-FROM golang:1.25-alpine AS builder
+# Base images 以 digest 釘選，避免浮動 tag 在重新建置時拉到不同內容
+# Dependabot (.github/dependabot.yml) 會自動開 PR 升級這些 digest
+FROM golang:1.25-alpine@sha256:8d22e29d960bc50cd025d93d5b7c7d220b1ee9aa7a239b3c8f55a57e987e8d45 AS builder
 
 # 安裝必要工具
 RUN apk add --no-cache git make
@@ -23,7 +25,8 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s" -o /app/bin/api cmd/api/main.go
 
 # Stage 2: 執行階段
-FROM alpine:latest
+# alpine:3.20 + digest 釘選（之前用 alpine:latest，浮動 tag 是穩定性與安全風險）
+FROM alpine:3.20@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc
 
 # 安裝必要工具
 # ca-certificates: HTTPS 連線需要

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,6 @@
 # 多階段建置 Dockerfile for Next.js Frontend
 # Stage 1: 依賴安裝階段
-FROM node:20-alpine AS deps
+FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293 AS deps
 
 # 安裝 pnpm
 RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
@@ -14,7 +14,7 @@ COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile
 
 # Stage 2: 建置階段
-FROM node:20-alpine AS builder
+FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293 AS builder
 
 # 安裝 pnpm
 RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
@@ -39,7 +39,7 @@ ENV NODE_OPTIONS="--max-old-space-size=1024"
 RUN pnpm build
 
 # Stage 3: 執行階段
-FROM node:20-alpine AS runner
+FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293 AS runner
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

Closes #83.

Eliminates the floating-tag risk class behind the last two incidents:
- \`next@16.0.0\` was ~2 months behind patch (root cause of the MCP RCE; fixed in PR #79).
- \`pnpm@latest\` silently upgraded to v11 in a build, breaking it (fixed in PR #80).

### Changes

- **\`.github/dependabot.yml\`** — weekly PRs for:
  - npm (\`/frontend\`), with Next.js and React grouped
  - gomod (\`/backend\`)
  - docker base images (frontend + backend Dockerfiles)
  - github-actions
- **\`.github/workflows/security-audit.yml\`** — runs on every PR and weekly (Mon 03:00 UTC):
  - \`pnpm audit --audit-level=high --prod\` for frontend
  - \`govulncheck ./...\` for backend
  - Both \`continue-on-error: true\` — surface issues, don't block merges; Dependabot handles the actual upgrade PRs.
- **\`backend/Dockerfile\`** — pin \`golang:1.25-alpine\` and \`alpine:3.20\` by digest. Previous runtime stage used \`alpine:latest\` (floating).
- **\`frontend/Dockerfile\`** — pin \`node:20-alpine\` by digest across deps/builder/runner stages.

## Test plan

- [ ] Workflow yaml is syntactically valid (GitHub will surface failures in the Actions tab)
- [ ] After merge, Dependabot opens its first PR within a week
- [ ] \`docker build\` of both Dockerfiles succeeds with the pinned digests
- [ ] No \`:latest\` or unpinned tag remains in any Dockerfile