### PR TITLE
security: intrusion detector + uptime monitoring runbook

### DIFF
--- a/scripts/README-detect-intrusion.md
+++ b/scripts/README-detect-intrusion.md
@@ -1,0 +1,93 @@
+# Intrusion & Availability Alerting
+
+Detector + runbook added after the 2026-05-08 Next.js MCP RCE incident, where the site was down for ~4 days before being noticed. The goal is the cheapest possible signal: "something is wrong, look at the host now."
+
+## Components
+
+### 1. Host-side intrusion detector (`scripts/detect-intrusion.sh`)
+
+Runs on the host (not inside any container), watches the containers, and alerts to the existing Discord webhook.
+
+Checks per run:
+
+- **Bad process names** — greps `docker top` output for `xmrig`, `kdevtmpfsi`, `kinsing`, `javae`, `c3pool`, `supportxmr`, `minerd`, `cpuminer`. These are the families seen in the 2026-05-08 incident plus the most common XMRig droppers.
+- **/tmp executables** — `find /tmp -type f -perm -u+x` inside each container. Hardened services (frontend, backend after #81) have `noexec` tmpfs so this should always be empty; the check still applies to `nginx`/`redis`/`postgres` until those are tightened too.
+- **Memory pressure** — `docker stats --no-stream`; if any watched container exceeds `MEM_THRESHOLD_PCT` (default 90%), alert. The miner's runaway CPU/memory was the first observable signal during the incident.
+
+#### Install
+
+```bash
+# Copy script onto the EC2 host (deploy.sh / your provisioning of choice)
+sudo install -m 0755 scripts/detect-intrusion.sh /opt/asset-manager/scripts/detect-intrusion.sh
+
+# Install jq if missing
+sudo apt-get install -y jq
+
+# Add to root crontab — every 5 minutes
+sudo crontab -e
+# Append:
+*/5 * * * * DISCORD_WEBHOOK_URL='<copy from .env.production>' /opt/asset-manager/scripts/detect-intrusion.sh >> /var/log/asset-manager-detect.log 2>&1
+```
+
+#### Tune
+
+- `CONTAINERS` (space-separated): default `asset-manager-frontend asset-manager-backend asset-manager-nginx`. Add postgres/redis if you also want to watch them.
+- `MEM_THRESHOLD_PCT`: default `90`. Lower for early warning, higher to reduce noise.
+
+#### Verify (acceptance criteria from issue #85)
+
+```bash
+# Fake a memory-pressure alert: stress the frontend until it's near limit
+docker exec asset-manager-frontend sh -c 'node -e "let a=[]; setInterval(()=>{a.push(Buffer.alloc(1024*1024))},10)"' &
+
+# Within 5 minutes, expect a Discord message:
+#   🚨 asset-manager 入侵偵測告警 (...)
+#   **[asset-manager-frontend] 記憶體用量 95.x% 超過閾值 90%**
+```
+
+### 2. External uptime monitor
+
+The detector is host-resident; if the host or network is the failure, it can't alert. Pair with an external check:
+
+**Cloudflare Health Checks** (free, recommended since DNS is already on Cloudflare):
+
+1. Cloudflare Dashboard → your zone → Traffic → Health Checks → Create.
+2. Type: HTTPS, Path: `/health`, Method: `GET`, Expected codes: `200`, Expected response body: `healthy`.
+3. Interval: 60s, Retries: 2, Timeout: 5s. Region: closest to EC2 (e.g. Western US).
+4. Notify: Discord webhook (Cloudflare → Notifications → Add → Health Check). Use the same `DISCORD_WEBHOOK_URL`.
+
+Alternative: UptimeRobot free tier (5-min interval, 50 monitors). Configure the same way against `https://asset.chienchuanw.com/health`.
+
+#### Verify
+
+```bash
+# Force a 503 by stopping nginx briefly
+ssh ec2 'docker stop asset-manager-nginx'
+# Wait 2-3 minutes — Cloudflare / UptimeRobot should fire a "DOWN" alert
+ssh ec2 'docker start asset-manager-nginx'
+# "UP" / recovery notification follows
+```
+
+## Runbook — receiving an alert
+
+1. **Confirm it's real.** `curl -I https://asset.chienchuanw.com/health` from your workstation. If 200, the host detector likely fired on memory/CPU; if 5xx, both detectors should be screaming.
+2. **SSH to the host.** `docker ps --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'` — anything restarting, anything CPU-pegged in `docker stats`?
+3. **For the "bad process" alert specifically (highest priority):**
+   - `docker top <container>` — identify the process and parent.
+   - Capture evidence before killing: `docker exec <c> ps auxf > /tmp/incident-$(date +%s).txt`.
+   - Stop the container: `docker stop <c>`. Do **not** `docker rm` — keep the filesystem layer for forensics.
+   - Rotate any secrets the container had access to (`.env.production` contents).
+   - File a follow-up incident issue referencing the original 2026-05-08 incident (PRs #79, #80).
+4. **For uptime / 5xx:** `docker compose logs --tail=200 <service>` — check for OOM kills, panic traces. If the host is fine but containers crashed, check disk: `df -h`.
+5. **Document.** Add a one-paragraph note to the project journal so future you / future me can correlate.
+
+## Why this design
+
+- **No agents, no extra daemons.** The 2026-05-08 root cause was an unmaintained dependency; piling on a Datadog agent or similar adds the same kind of attack surface this script is supposed to detect.
+- **Two independent layers.** Host detector catches what the external monitor cannot (process names, /tmp drops); external monitor catches what the host detector cannot (host-level outage).
+- **Reuses existing Discord webhook.** No new secrets, no new notification channel to forget about.
+
+## Related
+
+- Issue #24 — broader observability (structured logging, metrics). This is the minimum viable subset.
+- Issue #81 — container hardening (read-only fs + noexec /tmp). Once merged, the `/tmp executable` check becomes redundant on hardened services but still useful on nginx/postgres/redis.

--- a/scripts/detect-intrusion.sh
+++ b/scripts/detect-intrusion.sh
@@ -20,6 +20,14 @@ if [[ -z "${DISCORD_WEBHOOK_URL:-}" ]]; then
   exit 1
 fi
 
+# 硬依賴：jq 用來組 JSON、curl 用來送 webhook。少任何一個就讓 cron 看到 stderr 而非靜默失敗。
+for dep in jq curl docker; do
+  if ! command -v "$dep" >/dev/null 2>&1; then
+    echo "ERROR: required command '$dep' not found in PATH" >&2
+    exit 1
+  fi
+done
+
 HOSTNAME_S=$(hostname)
 ALERTS=()
 
@@ -42,7 +50,10 @@ check_bad_processes() {
   if echo "$procs" | grep -iE "$BAD_PROCS_REGEX" >/dev/null; then
     local matches
     matches=$(echo "$procs" | grep -iE "$BAD_PROCS_REGEX" | head -3)
-    ALERTS+=("**[$c] 已知挖礦/惡意程式名命中**\n\`\`\`\n$matches\n\`\`\`")
+    # printf -v 把實體換行寫進變數；單純的 "...\n..." 在 bash 雙引號中是字面 backslash-n
+    local entry
+    printf -v entry '**[%s] 已知挖礦/惡意程式名命中**\n```\n%s\n```' "$c" "$matches"
+    ALERTS+=("$entry")
   fi
 }
 
@@ -52,7 +63,9 @@ check_tmp_executables() {
   local exe_files
   exe_files=$(docker exec "$c" sh -c 'find /tmp -type f -perm -u+x 2>/dev/null | head -5' 2>/dev/null || true)
   if [[ -n "$exe_files" ]]; then
-    ALERTS+=("**[$c] /tmp 出現可執行檔**\n\`\`\`\n$exe_files\n\`\`\`")
+    local entry
+    printf -v entry '**[%s] /tmp 出現可執行檔**\n```\n%s\n```' "$c" "$exe_files"
+    ALERTS+=("$entry")
   fi
 }
 
@@ -85,12 +98,29 @@ if [[ ${#ALERTS[@]} -eq 0 ]]; then
   exit 0
 fi
 
-# 拼 payload
+# 拼 payload；Discord content 欄位上限 2000 字元，多重告警同時觸發會超過。
+header="🚨 asset-manager 入侵偵測告警 (${HOSTNAME_S})"
 joined=$(printf '%s\n\n' "${ALERTS[@]}")
-content=$(jq -Rn --arg c "🚨 asset-manager 入侵偵測告警 (${HOSTNAME_S})" --arg b "$joined" '{content: ($c + "\n\n" + $b)}')
+# 預留 ~150 字給 header + 截斷提示
+max_body=$((2000 - ${#header} - 150))
+if [[ ${#joined} -gt $max_body ]]; then
+  joined="${joined:0:$max_body}
 
-curl -sS -X POST "$DISCORD_WEBHOOK_URL" \
+…（訊息過長已截斷，共 ${#ALERTS[@]} 項，請登入主機查看完整輸出）"
+fi
+content=$(jq -Rn --arg c "$header" --arg b "$joined" '{content: ($c + "\n\n" + $b)}')
+
+# 把 curl 的 HTTP code 抓出來，非 2xx 時讓 cron 看到 stderr
+http_code=$(curl -sS -o /tmp/discord-resp.$$ -w '%{http_code}' \
+  -X POST "$DISCORD_WEBHOOK_URL" \
   -H "Content-Type: application/json" \
-  -d "$content" >/dev/null
+  -d "$content")
+if [[ "$http_code" != 2* ]]; then
+  echo "ERROR: Discord webhook returned HTTP $http_code" >&2
+  cat /tmp/discord-resp.$$ >&2
+  rm -f /tmp/discord-resp.$$
+  exit 2
+fi
+rm -f /tmp/discord-resp.$$
 
 echo "$(date -u +%FT%TZ) alerted: ${#ALERTS[@]} item(s)"

--- a/scripts/detect-intrusion.sh
+++ b/scripts/detect-intrusion.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# 入侵與資源異常偵測（2026-05-08 RCE 事件後新增）
+#
+# 設計目標：以最少的依賴（docker + curl + awk）在主機 cron 跑，
+# 偵測下列幾類訊號並透過 Discord webhook 通知：
+#   1. 已知挖礦/惡意程式名出現在任何容器內
+#   2. /tmp 出現可執行檔（這是上次事件中 XMRig 落地的具體手法）
+#   3. 容器記憶體用量長時間貼近 limit
+#
+# Usage:
+#   DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/... ./scripts/detect-intrusion.sh
+#
+# Cron 範例（每 5 分鐘跑一次）：
+#   */5 * * * * DISCORD_WEBHOOK_URL=... /opt/asset-manager/scripts/detect-intrusion.sh >> /var/log/asset-manager-detect.log 2>&1
+
+set -uo pipefail
+
+if [[ -z "${DISCORD_WEBHOOK_URL:-}" ]]; then
+  echo "ERROR: DISCORD_WEBHOOK_URL not set" >&2
+  exit 1
+fi
+
+HOSTNAME_S=$(hostname)
+ALERTS=()
+
+# 觀察哪些容器；可由 CONTAINERS 環境變數覆寫
+CONTAINERS=${CONTAINERS:-"asset-manager-frontend asset-manager-backend asset-manager-nginx"}
+
+# 已知挖礦/惡意程式名（小寫，會 grep -i）
+BAD_PROCS_REGEX='xmrig|kdevtmpfsi|kinsing|javae|c3pool|supportxmr|minerd|cpuminer'
+
+# 記憶體閾值：超過 limit 的此百分比就告警
+MEM_THRESHOLD_PCT=${MEM_THRESHOLD_PCT:-90}
+
+check_bad_processes() {
+  local c="$1"
+  # docker top 失敗（容器不存在/未跑）就跳過
+  local procs
+  if ! procs=$(docker top "$c" -eo pid,comm,args 2>/dev/null); then
+    return
+  fi
+  if echo "$procs" | grep -iE "$BAD_PROCS_REGEX" >/dev/null; then
+    local matches
+    matches=$(echo "$procs" | grep -iE "$BAD_PROCS_REGEX" | head -3)
+    ALERTS+=("**[$c] 已知挖礦/惡意程式名命中**\n\`\`\`\n$matches\n\`\`\`")
+  fi
+}
+
+check_tmp_executables() {
+  local c="$1"
+  # 容器掛 read-only + tmpfs noexec 後此項應永遠為空；但 nginx/postgres/redis 等未強化容器仍適用。
+  local exe_files
+  exe_files=$(docker exec "$c" sh -c 'find /tmp -type f -perm -u+x 2>/dev/null | head -5' 2>/dev/null || true)
+  if [[ -n "$exe_files" ]]; then
+    ALERTS+=("**[$c] /tmp 出現可執行檔**\n\`\`\`\n$exe_files\n\`\`\`")
+  fi
+}
+
+check_memory_pressure() {
+  # docker stats: 一次取一個 snapshot
+  local stats
+  stats=$(docker stats --no-stream --format '{{.Name}} {{.MemPerc}}' 2>/dev/null || true)
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    local name pct
+    name=$(echo "$line" | awk '{print $1}')
+    pct=$(echo "$line" | awk '{print $2}' | tr -d '%')
+    # 只看我們關心的容器
+    if ! [[ " $CONTAINERS " =~ " $name " ]]; then continue; fi
+    # bash 不會做小數比較，用 awk
+    if awk -v p="$pct" -v t="$MEM_THRESHOLD_PCT" 'BEGIN{exit !(p+0 > t+0)}'; then
+      ALERTS+=("**[$name] 記憶體用量 ${pct}% 超過閾值 ${MEM_THRESHOLD_PCT}%**")
+    fi
+  done <<<"$stats"
+}
+
+for c in $CONTAINERS; do
+  check_bad_processes "$c"
+  check_tmp_executables "$c"
+done
+check_memory_pressure
+
+if [[ ${#ALERTS[@]} -eq 0 ]]; then
+  echo "$(date -u +%FT%TZ) ok"
+  exit 0
+fi
+
+# 拼 payload
+joined=$(printf '%s\n\n' "${ALERTS[@]}")
+content=$(jq -Rn --arg c "🚨 asset-manager 入侵偵測告警 (${HOSTNAME_S})" --arg b "$joined" '{content: ($c + "\n\n" + $b)}')
+
+curl -sS -X POST "$DISCORD_WEBHOOK_URL" \
+  -H "Content-Type: application/json" \
+  -d "$content" >/dev/null
+
+echo "$(date -u +%FT%TZ) alerted: ${#ALERTS[@]} item(s)"


### PR DESCRIPTION
## Summary

Closes #85.

Adds the smallest-viable alerting layer that would have caught the 2026-05-08 RCE / XMRig miner incident before ~4 days of downtime. Two independent layers, both feeding the existing Discord webhook.

### Host-side detector — \`scripts/detect-intrusion.sh\`

Runs from root crontab every 5 minutes. Checks:

1. **Known miner process names** in any container (\`xmrig\`, \`kdevtmpfsi\`, \`kinsing\`, \`javae\`, \`c3pool\`, \`supportxmr\`, \`minerd\`, \`cpuminer\`)
2. **Executable files in \`/tmp\`** inside each container (the specific drop step XMRig used)
3. **Memory pressure** — any watched container exceeding \`MEM_THRESHOLD_PCT\` (default 90%)

Silent when healthy; posts a single Discord message listing every triggered check when something fires.

### External uptime layer — runbook

\`scripts/README-detect-intrusion.md\` documents setting up Cloudflare Health Checks (preferred, since DNS is already on Cloudflare) or UptimeRobot against \`/health\`, plus an incident runbook (capture evidence → stop container → rotate secrets → file follow-up).

### Why this and not Datadog/Prometheus

The 2026-05-08 root cause was an unmaintained dependency. Piling on an agent adds exactly the kind of surface this is meant to detect. Bash + Discord is enough for "something is wrong, look now."

## Test plan

- [ ] \`bash -n scripts/detect-intrusion.sh\` passes (verified locally)
- [ ] After install: manually stress frontend memory → Discord alert within 5 min
- [ ] Manually \`docker stop asset-manager-nginx\` → Cloudflare/UptimeRobot DOWN alert within ~2 min
- [ ] Healthy steady state: cron log shows \`<timestamp> ok\` and no Discord noise

## Related

- #24 — broader observability (logging/metrics); this PR is the minimum subset focused on intrusion + availability.
- #81 — container hardening: once merged, the /tmp check is redundant on frontend/backend but stays useful for nginx/redis/postgres.