### PR TITLE
feat: 設計系統與外殼重構（Ghostfolio 風格 — 子專案 A）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ openspec/
 # Planning docs
 docs/
 note/
+
+# Brainstorming visual companion
+.superpowers/

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -718,5 +718,12 @@
     "networkError": "Network connection error",
     "unauthorized": "Unauthorized, please login again",
     "serverError": "Server error"
+  },
+  "states": {
+    "emptyTitle": "No data yet",
+    "emptyDescription": "There's nothing to show here right now.",
+    "loading": "Loading…",
+    "errorTitle": "Couldn't load data",
+    "retry": "Retry"
   }
 }

--- a/frontend/messages/zh-TW.json
+++ b/frontend/messages/zh-TW.json
@@ -754,5 +754,12 @@
     "networkError": "網路連線錯誤",
     "unauthorized": "未授權，請重新登入",
     "serverError": "伺服器錯誤"
+  },
+  "states": {
+    "emptyTitle": "尚無資料",
+    "emptyDescription": "目前沒有可顯示的內容。",
+    "loading": "載入中…",
+    "errorTitle": "資料載入失敗",
+    "retry": "重試"
   }
 }

--- a/frontend/src/app/analytics/page.tsx
+++ b/frontend/src/app/analytics/page.tsx
@@ -40,11 +40,8 @@ import { Loading } from "@/components/ui/loading";
 import { useAnalytics } from "@/hooks/useAnalytics";
 import { useUnrealizedAnalytics } from "@/hooks/useUnrealizedAnalytics";
 import { TimeRange } from "@/types/analytics";
-import {
-  formatCurrency,
-  formatPercentage,
-  isPositive,
-} from "@/types/analytics";
+import { formatPercentage, isPositive } from "@/types/analytics";
+import { formatCurrency } from "@/lib/format";
 import { getAssetTypeLabel } from "@/types/transaction";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 

--- a/frontend/src/app/analytics/page.tsx
+++ b/frontend/src/app/analytics/page.tsx
@@ -41,7 +41,7 @@ import { useAnalytics } from "@/hooks/useAnalytics";
 import { useUnrealizedAnalytics } from "@/hooks/useUnrealizedAnalytics";
 import { TimeRange } from "@/types/analytics";
 import { formatPercentage, isPositive } from "@/types/analytics";
-import { formatCurrency } from "@/lib/format";
+import { Money } from "@/components/common/Money";
 import { getAssetTypeLabel } from "@/types/transaction";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 
@@ -126,10 +126,10 @@ export default function AnalyticsPage() {
                         </CardHeader>
                         <CardContent>
                           <div className="text-2xl font-bold tabular-nums">
-                            {formatCurrency(
-                              realizedData.summary.data.total_cost_basis,
-                              realizedData.summary.data.currency
-                            )}
+                            <Money
+                              value={realizedData.summary.data.total_cost_basis}
+                              currency={realizedData.summary.data.currency}
+                            />
                           </div>
                           <p className="text-xs text-muted-foreground mt-1">
                             {t("sellTransactionCost")}
@@ -145,10 +145,10 @@ export default function AnalyticsPage() {
                         </CardHeader>
                         <CardContent>
                           <div className="text-2xl font-bold tabular-nums">
-                            {formatCurrency(
-                              realizedData.summary.data.total_sell_amount,
-                              realizedData.summary.data.currency
-                            )}
+                            <Money
+                              value={realizedData.summary.data.total_sell_amount}
+                              currency={realizedData.summary.data.currency}
+                            />
                           </div>
                           <p className="text-xs text-muted-foreground mt-1">
                             {t("actualSellIncome")}
@@ -170,10 +170,10 @@ export default function AnalyticsPage() {
                                 : "text-red-600"
                             }`}
                           >
-                            {formatCurrency(
-                              realizedData.summary.data.total_realized_pl,
-                              realizedData.summary.data.currency
-                            )}
+                            <Money
+                              value={realizedData.summary.data.total_realized_pl}
+                              currency={realizedData.summary.data.currency}
+                            />
                           </div>
                           <p className="text-xs text-muted-foreground mt-1">
                             {t("actualProfitLoss")}
@@ -347,7 +347,7 @@ export default function AnalyticsPage() {
                                           : "text-red-600"
                                       }`}
                                     >
-                                      {formatCurrency(item.realized_pl, "TWD")}
+                                      <Money value={item.realized_pl} currency="TWD" />
                                     </span>
                                   </div>
                                 </div>
@@ -414,10 +414,10 @@ export default function AnalyticsPage() {
                                     </Badge>
                                   </TableCell>
                                   <TableCell className="text-right tabular-nums">
-                                    {formatCurrency(asset.cost_basis, "TWD")}
+                                    <Money value={asset.cost_basis} currency="TWD" />
                                   </TableCell>
                                   <TableCell className="text-right tabular-nums">
-                                    {formatCurrency(asset.sell_amount, "TWD")}
+                                    <Money value={asset.sell_amount} currency="TWD" />
                                   </TableCell>
                                   <TableCell
                                     className={`text-right font-medium tabular-nums ${
@@ -426,7 +426,7 @@ export default function AnalyticsPage() {
                                         : "text-red-600"
                                     }`}
                                   >
-                                    {formatCurrency(asset.realized_pl, "TWD")}
+                                    <Money value={asset.realized_pl} currency="TWD" />
                                   </TableCell>
                                   <TableCell
                                     className={`text-right font-medium tabular-nums ${
@@ -483,10 +483,10 @@ export default function AnalyticsPage() {
                         </CardHeader>
                         <CardContent>
                           <div className="text-2xl font-bold tabular-nums">
-                            {formatCurrency(
-                              unrealizedData.summary.data.total_cost,
-                              unrealizedData.summary.data.currency
-                            )}
+                            <Money
+                              value={unrealizedData.summary.data.total_cost}
+                              currency={unrealizedData.summary.data.currency}
+                            />
                           </div>
                           <p className="text-xs text-muted-foreground mt-1">
                             {t("holdingCostBasis")}
@@ -502,10 +502,10 @@ export default function AnalyticsPage() {
                         </CardHeader>
                         <CardContent>
                           <div className="text-2xl font-bold tabular-nums">
-                            {formatCurrency(
-                              unrealizedData.summary.data.total_market_value,
-                              unrealizedData.summary.data.currency
-                            )}
+                            <Money
+                              value={unrealizedData.summary.data.total_market_value}
+                              currency={unrealizedData.summary.data.currency}
+                            />
                           </div>
                           <p className="text-xs text-muted-foreground mt-1">
                             {t("currentMarketValue")}
@@ -527,10 +527,10 @@ export default function AnalyticsPage() {
                                 : "text-red-600"
                             }`}
                           >
-                            {formatCurrency(
-                              unrealizedData.summary.data.total_unrealized_pl,
-                              unrealizedData.summary.data.currency
-                            )}
+                            <Money
+                              value={unrealizedData.summary.data.total_unrealized_pl}
+                              currency={unrealizedData.summary.data.currency}
+                            />
                           </div>
                           <p className="text-xs text-muted-foreground mt-1">
                             {t("floatingPL")}
@@ -687,10 +687,7 @@ export default function AnalyticsPage() {
                                           : "text-red-600"
                                       }`}
                                     >
-                                      {formatCurrency(
-                                        item.unrealized_pl,
-                                        "TWD"
-                                      )}
+                                      <Money value={item.unrealized_pl} currency="TWD" />
                                     </span>
                                   </div>
                                 </div>
@@ -763,10 +760,10 @@ export default function AnalyticsPage() {
                                     {asset.quantity.toLocaleString("zh-TW")}
                                   </TableCell>
                                   <TableCell className="text-right tabular-nums">
-                                    {formatCurrency(asset.avg_cost, "TWD")}
+                                    <Money value={asset.avg_cost} currency="TWD" />
                                   </TableCell>
                                   <TableCell className="text-right tabular-nums">
-                                    {formatCurrency(asset.current_price, "TWD")}
+                                    <Money value={asset.current_price} currency="TWD" />
                                   </TableCell>
                                   <TableCell
                                     className={`text-right font-medium tabular-nums ${
@@ -775,7 +772,7 @@ export default function AnalyticsPage() {
                                         : "text-red-600"
                                     }`}
                                   >
-                                    {formatCurrency(asset.unrealized_pl, "TWD")}
+                                    <Money value={asset.unrealized_pl} currency="TWD" />
                                   </TableCell>
                                   <TableCell
                                     className={`text-right font-medium tabular-nums ${

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -41,6 +41,11 @@
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
   --radius-xl: calc(var(--radius) + 4px);
+  --color-gain: var(--gain);
+  --color-loss: var(--loss);
+  --color-neutral: var(--neutral);
+  --color-surface: var(--surface);
+  --color-surface-border: var(--surface-border);
 }
 
 :root {
@@ -76,6 +81,11 @@
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
+  --gain: oklch(0.72 0.17 152);
+  --loss: oklch(0.62 0.21 25);
+  --neutral: oklch(0.55 0 0);
+  --surface: oklch(0.985 0 0);
+  --surface-border: oklch(0.92 0 0);
 }
 
 .dark {
@@ -110,6 +120,11 @@
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.556 0 0);
+  --gain: oklch(0.78 0.16 158);
+  --loss: oklch(0.68 0.19 25);
+  --neutral: oklch(0.65 0 0);
+  --surface: oklch(0.2 0.01 250);
+  --surface-border: oklch(0.27 0.01 250);
 }
 
 @layer base {

--- a/frontend/src/app/holdings/page.tsx
+++ b/frontend/src/app/holdings/page.tsx
@@ -37,12 +37,12 @@ import {
   calculateTotalCost,
   calculateTotalProfitLoss,
   calculateTotalProfitLossPct,
-  formatCurrency,
   formatPercentage,
   getProfitLossColor,
   getConvertedStyle,
 } from "@/types/holding";
 import type { Holding } from "@/types/holding";
+import { Money } from "@/components/common/Money";
 import { InsufficientQuantityDialog } from "@/components/holdings/InsufficientQuantityDialog";
 import { BatchReconcileHoldingsDialog } from "@/components/holdings/BatchReconcileHoldingsDialog";
 import { holdingsAPI } from "@/lib/api/holdings";
@@ -183,12 +183,14 @@ function HoldingCard({
                                 : getProfitLossColor(holding.unrealized_pl)
                             }`}
                           >
-                            {showInTWD
-                              ? formatCurrency(holding.unrealized_pl, "TWD")
-                              : formatCurrency(
-                                  originalValues.unrealizedPL,
-                                  holding.currency
-                                )}
+                            {showInTWD ? (
+                              <Money value={holding.unrealized_pl} currency="TWD" />
+                            ) : (
+                              <Money
+                                value={originalValues.unrealizedPL}
+                                currency={holding.currency}
+                              />
+                            )}
                           </span>
                           <span
                             className={`text-xs tabular-nums ${
@@ -481,7 +483,7 @@ export default function HoldingsPage() {
                     stats.totalProfitLoss
                   )}`}
                 >
-                  {formatCurrency(stats.totalProfitLoss, "TWD")}
+                  <Money value={stats.totalProfitLoss} currency="TWD" />
                 </CardTitle>
               </CardHeader>
             </Card>
@@ -533,7 +535,7 @@ export default function HoldingsPage() {
                     stats.availableCash
                   )}`}
                 >
-                  {formatCurrency(stats.availableCash, "TWD")}
+                  <Money value={stats.availableCash} currency="TWD" />
                 </CardTitle>
               </CardHeader>
             </Card>

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { getLocale, getMessages } from "next-intl/server";
 import { QueryProvider } from "@/providers/QueryProvider";
 import { AuthProvider } from "@/providers/AuthProvider";
 import { LocaleProvider } from "@/providers/LocaleProvider";
+import { ThemeProvider } from "@/providers/ThemeProvider";
 import { Toaster } from "@/components/ui/sonner";
 import { Locale } from "@/i18n/config";
 
@@ -34,19 +35,21 @@ export default async function RootLayout({
   const messages = await getMessages();
 
   return (
-    <html lang={locale}>
+    <html lang={locale} suppressHydrationWarning>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <NextIntlClientProvider messages={messages}>
-          <LocaleProvider initialLocale={locale as Locale}>
-            <QueryProvider>
-              <AuthProvider>
-                {children}
-                <Toaster />
-              </AuthProvider>
-            </QueryProvider>
-          </LocaleProvider>
+          <ThemeProvider>
+            <LocaleProvider initialLocale={locale as Locale}>
+              <QueryProvider>
+                <AuthProvider>
+                  {children}
+                  <Toaster />
+                </AuthProvider>
+              </QueryProvider>
+            </LocaleProvider>
+          </ThemeProvider>
         </NextIntlClientProvider>
       </body>
     </html>

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { QueryProvider } from "@/providers/QueryProvider";
 import { AuthProvider } from "@/providers/AuthProvider";
 import { LocaleProvider } from "@/providers/LocaleProvider";
 import { ThemeProvider } from "@/providers/ThemeProvider";
+import { ZenModeProvider } from "@/providers/ZenModeProvider";
 import { Toaster } from "@/components/ui/sonner";
 import { Locale } from "@/i18n/config";
 
@@ -41,14 +42,16 @@ export default async function RootLayout({
       >
         <NextIntlClientProvider messages={messages}>
           <ThemeProvider>
-            <LocaleProvider initialLocale={locale as Locale}>
-              <QueryProvider>
-                <AuthProvider>
-                  {children}
-                  <Toaster />
-                </AuthProvider>
-              </QueryProvider>
-            </LocaleProvider>
+            <ZenModeProvider>
+              <LocaleProvider initialLocale={locale as Locale}>
+                <QueryProvider>
+                  <AuthProvider>
+                    {children}
+                    <Toaster />
+                  </AuthProvider>
+                </QueryProvider>
+              </LocaleProvider>
+            </ZenModeProvider>
           </ThemeProvider>
         </NextIntlClientProvider>
       </body>

--- a/frontend/src/components/cash-flows/MonthlyExpenseChart.tsx
+++ b/frontend/src/components/cash-flows/MonthlyExpenseChart.tsx
@@ -13,6 +13,7 @@ import { useCashFlows } from "@/hooks";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { CashFlowType, formatAmount } from "@/types/cash-flow";
 import { Skeleton } from "@/components/ui/skeleton";
+import { chartTheme } from "@/lib/chartTheme";
 
 interface MonthlyExpenseChartProps {
   selectedDate: string; // ISO 8601 格式 (YYYY-MM-DD)
@@ -162,11 +163,11 @@ export function MonthlyExpenseChart({
   const chartConfig = {
     income: {
       label: t("income"),
-      color: "#22c55e", // 綠色
+      color: chartTheme.gain,
     },
     expense: {
       label: t("expense"),
-      color: "#ef4444", // 紅色
+      color: chartTheme.loss,
     },
   } satisfies ChartConfig;
 

--- a/frontend/src/components/common/Money.test.tsx
+++ b/frontend/src/components/common/Money.test.tsx
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+const zenState = { zen: false };
+vi.mock("@/providers/ZenModeProvider", () => ({
+  useZenMode: () => ({ zen: zenState.zen, toggleZen: vi.fn() }),
+}));
+
+import { Money } from "./Money";
+
+describe("Money", () => {
+  it("renders formatted currency when zen is off", () => {
+    zenState.zen = false;
+    render(<Money value={1284500} currency="TWD" />);
+    expect(screen.getByText("NT$1,284,500")).toBeInTheDocument();
+  });
+
+  it("masks the amount when zen is on", () => {
+    zenState.zen = true;
+    render(<Money value={1284500} currency="TWD" />);
+    expect(screen.queryByText("NT$1,284,500")).not.toBeInTheDocument();
+    expect(screen.getByText(/•+/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/common/Money.tsx
+++ b/frontend/src/components/common/Money.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { useZenMode } from "@/providers/ZenModeProvider";
+import { formatCurrency } from "@/lib/format";
+
+type MoneyProps = {
+  value: number;
+  currency?: string;
+  className?: string;
+};
+
+export function Money({ value, currency = "TWD", className }: MoneyProps) {
+  const { zen } = useZenMode();
+  return (
+    <span className={className}>
+      {zen ? "NT$•••••" : formatCurrency(value, currency)}
+    </span>
+  );
+}

--- a/frontend/src/components/common/ThemeToggle.test.tsx
+++ b/frontend/src/components/common/ThemeToggle.test.tsx
@@ -1,0 +1,17 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+const setTheme = vi.fn();
+vi.mock("next-themes", () => ({
+  useTheme: () => ({ theme: "light", setTheme }),
+}));
+
+import { ThemeToggle } from "./ThemeToggle";
+
+describe("ThemeToggle", () => {
+  it("switches to dark when toggled from light", () => {
+    render(<ThemeToggle />);
+    fireEvent.click(screen.getByRole("button", { name: /theme/i }));
+    expect(setTheme).toHaveBeenCalledWith("dark");
+  });
+});

--- a/frontend/src/components/common/ThemeToggle.tsx
+++ b/frontend/src/components/common/ThemeToggle.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useTheme } from "next-themes";
+import { Moon, Sun } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      aria-label="Toggle theme"
+      onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+    >
+      <Sun className="h-4 w-4 dark:hidden" />
+      <Moon className="hidden h-4 w-4 dark:block" />
+    </Button>
+  );
+}

--- a/frontend/src/components/common/ZenModeToggle.test.tsx
+++ b/frontend/src/components/common/ZenModeToggle.test.tsx
@@ -1,0 +1,17 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+const toggleZen = vi.fn();
+vi.mock("@/providers/ZenModeProvider", () => ({
+  useZenMode: () => ({ zen: false, toggleZen }),
+}));
+
+import { ZenModeToggle } from "./ZenModeToggle";
+
+describe("ZenModeToggle", () => {
+  it("calls toggleZen on click", () => {
+    render(<ZenModeToggle />);
+    fireEvent.click(screen.getByRole("button", { name: /zen/i }));
+    expect(toggleZen).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/components/common/ZenModeToggle.tsx
+++ b/frontend/src/components/common/ZenModeToggle.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { useZenMode } from "@/providers/ZenModeProvider";
+import { Eye, EyeOff } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export function ZenModeToggle() {
+  const { zen, toggleZen } = useZenMode();
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      aria-label="Toggle zen mode"
+      onClick={toggleZen}
+    >
+      {zen ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+    </Button>
+  );
+}

--- a/frontend/src/components/dashboard/AssetAllocationChart.tsx
+++ b/frontend/src/components/dashboard/AssetAllocationChart.tsx
@@ -16,6 +16,8 @@ import {
 } from "@/components/ui/card";
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from "recharts";
 import { AssetType } from "@/types/transaction";
+import { chartTheme } from "@/lib/chartTheme";
+import { EmptyState } from "@/components/ui/states/EmptyState";
 
 interface AssetAllocationData {
   name: string;
@@ -26,11 +28,11 @@ interface AssetAllocationChartProps {
   data: AssetAllocationData[];
 }
 
-// 資產類型顏色對應
+// 資產類型顏色對應(由設計 token 衍生,與 AssetTrendChart 一致)
 const ASSET_COLORS: Record<string, string> = {
-  "tw-stock": "#3b82f6", // 藍色
-  "us-stock": "#10b981", // 綠色
-  crypto: "#f59e0b", // 橘色
+  "tw-stock": chartTheme.series[0],
+  "us-stock": chartTheme.series[1],
+  crypto: chartTheme.series[2],
 };
 
 export function AssetAllocationChart({ data }: AssetAllocationChartProps) {
@@ -57,7 +59,7 @@ export function AssetAllocationChart({ data }: AssetAllocationChartProps) {
       assetType: item.name,
       value: item.value,
       percentage: total > 0 ? (item.value / total) * 100 : 0,
-      color: ASSET_COLORS[item.name] || "#6b7280",
+      color: ASSET_COLORS[item.name] || chartTheme.neutral,
     }));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data, tAssets]);
@@ -98,9 +100,7 @@ export function AssetAllocationChart({ data }: AssetAllocationChartProps) {
       </CardHeader>
       <CardContent>
         {chartData.length === 0 ? (
-          <div className="h-[300px] flex items-center justify-center text-muted-foreground">
-            {t("noData")}
-          </div>
+          <EmptyState />
         ) : (
           <>
             <div className="h-[200px] min-h-[200px]">
@@ -112,7 +112,7 @@ export function AssetAllocationChart({ data }: AssetAllocationChartProps) {
                     cy="50%"
                     labelLine={false}
                     outerRadius={90}
-                    fill="#8884d8"
+                    fill={chartTheme.neutral}
                     dataKey="value"
                   >
                     {chartData.map((entry, index) => (

--- a/frontend/src/components/dashboard/AssetTrendChart.tsx
+++ b/frontend/src/components/dashboard/AssetTrendChart.tsx
@@ -14,8 +14,6 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { Skeleton } from "@/components/ui/skeleton";
-import { AlertCircle } from "lucide-react";
 import {
   LineChart,
   Line,
@@ -26,11 +24,14 @@ import {
   ResponsiveContainer,
 } from "recharts";
 import { useAssetTrend } from "@/hooks";
+import { chartTheme } from "@/lib/chartTheme";
+import { EmptyState } from "@/components/ui/states/EmptyState";
+import { LoadingState } from "@/components/ui/states/LoadingState";
+import { ErrorState } from "@/components/ui/states/ErrorState";
 
 export function AssetTrendChart() {
   const t = useTranslations("dashboard");
   const tAssets = useTranslations("assetTypes");
-  const tErrors = useTranslations("errors");
   // 使用 state 來延遲渲染圖表,避免 SSR 問題
   const [mounted, setMounted] = useState(false);
 
@@ -168,30 +169,13 @@ export function AssetTrendChart() {
       </CardHeader>
       <CardContent className="px-2 pt-4 sm:px-6 sm:pt-6">
         {/* Loading 狀態 */}
-        {isLoading && (
-          <div className="h-[300px] w-full">
-            <Skeleton className="h-full w-full" />
-          </div>
-        )}
+        {isLoading && <LoadingState variant="chart" />}
 
         {/* Error 狀態 */}
-        {!isLoading && totalError && (
-          <div className="h-[300px] w-full flex items-center justify-center">
-            <div className="flex items-center gap-2 text-red-600">
-              <AlertCircle className="h-5 w-5" />
-              <p className="text-sm">
-                {tErrors("loadFailed")}: {totalError.message}
-              </p>
-            </div>
-          </div>
-        )}
+        {!isLoading && totalError && <ErrorState />}
 
         {/* 空資料狀態 */}
-        {!isLoading && !totalError && chartData.length === 0 && (
-          <div className="h-[300px] w-full flex items-center justify-center">
-            <p className="text-sm text-muted-foreground">{t("noData")}</p>
-          </div>
-        )}
+        {!isLoading && !totalError && chartData.length === 0 && <EmptyState />}
 
         {/* 圖表 */}
         {!isLoading && !totalError && chartData.length > 0 && mounted && (
@@ -209,7 +193,7 @@ export function AssetTrendChart() {
                 <CartesianGrid
                   strokeDasharray="3 3"
                   vertical={false}
-                  className="stroke-muted"
+                  stroke={chartTheme.grid.stroke}
                 />
                 <XAxis
                   dataKey="date"
@@ -230,7 +214,7 @@ export function AssetTrendChart() {
                   type="monotone"
                   dataKey="total"
                   name={tAssets("total")}
-                  stroke="#111827"
+                  stroke={chartTheme.neutral}
                   strokeWidth={2}
                   dot={false}
                 />
@@ -238,7 +222,7 @@ export function AssetTrendChart() {
                   type="monotone"
                   dataKey="twStock"
                   name={tAssets("twStock")}
-                  stroke="#3b82f6"
+                  stroke={chartTheme.series[0]}
                   strokeWidth={1.5}
                   dot={false}
                   strokeOpacity={0.7}
@@ -247,7 +231,7 @@ export function AssetTrendChart() {
                   type="monotone"
                   dataKey="usStock"
                   name={tAssets("usStock")}
-                  stroke="#10b981"
+                  stroke={chartTheme.series[1]}
                   strokeWidth={1.5}
                   dot={false}
                   strokeOpacity={0.7}
@@ -256,7 +240,7 @@ export function AssetTrendChart() {
                   type="monotone"
                   dataKey="crypto"
                   name={tAssets("crypto")}
-                  stroke="#f59e0b"
+                  stroke={chartTheme.series[2]}
                   strokeWidth={1.5}
                   dot={false}
                   strokeOpacity={0.7}

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -40,6 +40,8 @@ import {
 import { Separator } from "@/components/ui/separator";
 import { useAuth } from "@/providers/AuthProvider";
 import { LanguageSwitcher } from "@/components/common/LanguageSwitcher";
+import { ThemeToggle } from "@/components/common/ThemeToggle";
+import { ZenModeToggle } from "@/components/common/ZenModeToggle";
 
 interface AppLayoutProps {
   children: React.ReactNode;
@@ -255,7 +257,9 @@ export function AppLayout({ children, title, description }: AppLayoutProps) {
             </div>
           )}
 
-          {/* 語言切換 */}
+          {/* 主題、Zen 模式與語言切換 */}
+          <ThemeToggle />
+          <ZenModeToggle />
           <LanguageSwitcher />
         </header>
 

--- a/frontend/src/components/rebalance/AllocationTable.test.tsx
+++ b/frontend/src/components/rebalance/AllocationTable.test.tsx
@@ -79,6 +79,6 @@ describe("AllocationTable", () => {
       <AllocationTable deviations={[]} threshold={5} />
     );
 
-    expect(screen.getByText("No data")).toBeInTheDocument();
+    expect(screen.getByText("No data yet")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/rebalance/AllocationTable.tsx
+++ b/frontend/src/components/rebalance/AllocationTable.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/components/ui/table";
 import type { AssetTypeDeviation } from "@/types/rebalance";
 import { ASSET_TYPE_MAP } from "./constants";
+import { EmptyState } from "@/components/ui/states/EmptyState";
 
 interface AllocationTableProps {
   deviations: AssetTypeDeviation[];
@@ -35,7 +36,6 @@ export function AllocationTable({
 }: AllocationTableProps) {
   const t = useTranslations("rebalance");
   const tAssets = useTranslations("assetTypes");
-  const tCommon = useTranslations("common");
 
   /**
    * 取得資產類別的顯示名稱
@@ -73,9 +73,7 @@ export function AllocationTable({
       </CardHeader>
       <CardContent>
         {deviations.length === 0 ? (
-          <div className="text-center py-8 text-muted-foreground">
-            {tCommon("noData")}
-          </div>
+          <EmptyState />
         ) : (
           <div className="rounded-md border">
             <Table>

--- a/frontend/src/components/ui/states/EmptyState.tsx
+++ b/frontend/src/components/ui/states/EmptyState.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Inbox } from "lucide-react";
+
+export function EmptyState({
+  title,
+  description,
+  action,
+}: {
+  title?: string;
+  description?: string;
+  action?: React.ReactNode;
+}) {
+  const t = useTranslations("states");
+  return (
+    <div className="flex h-full min-h-[200px] w-full flex-col items-center justify-center gap-2 text-center">
+      <Inbox className="h-8 w-8 text-muted-foreground" />
+      <p className="text-sm font-medium">{title ?? t("emptyTitle")}</p>
+      <p className="text-xs text-muted-foreground">
+        {description ?? t("emptyDescription")}
+      </p>
+      {action}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/states/ErrorState.tsx
+++ b/frontend/src/components/ui/states/ErrorState.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { AlertCircle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export function ErrorState({
+  message,
+  onRetry,
+}: {
+  message?: string;
+  onRetry?: () => void;
+}) {
+  const t = useTranslations("states");
+  return (
+    <div className="flex h-full min-h-[200px] w-full flex-col items-center justify-center gap-3 text-center">
+      <AlertCircle className="h-8 w-8 text-loss" />
+      <p className="text-sm">{message ?? t("errorTitle")}</p>
+      {onRetry && (
+        <Button variant="outline" size="sm" onClick={onRetry}>
+          {t("retry")}
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/states/LoadingState.tsx
+++ b/frontend/src/components/ui/states/LoadingState.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { Skeleton } from "@/components/ui/skeleton";
+
+type Variant = "card" | "table" | "chart";
+
+export function LoadingState({ variant = "card" }: { variant?: Variant }) {
+  if (variant === "chart") {
+    return <Skeleton className="h-[300px] w-full" />;
+  }
+  if (variant === "table") {
+    return (
+      <div className="space-y-2">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Skeleton key={i} className="h-10 w-full" />
+        ))}
+      </div>
+    );
+  }
+  return (
+    <div className="space-y-3">
+      <Skeleton className="h-5 w-1/3" />
+      <Skeleton className="h-8 w-2/3" />
+    </div>
+  );
+}

--- a/frontend/src/components/ui/states/states.test.tsx
+++ b/frontend/src/components/ui/states/states.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (k: string) => k,
+}));
+
+import { EmptyState } from "./EmptyState";
+import { LoadingState } from "./LoadingState";
+import { ErrorState } from "./ErrorState";
+
+describe("state components", () => {
+  it("EmptyState renders title", () => {
+    render(<EmptyState />);
+    expect(screen.getByText("emptyTitle")).toBeInTheDocument();
+  });
+
+  it("LoadingState renders the chart variant skeleton", () => {
+    const { container } = render(<LoadingState variant="chart" />);
+    expect(container.querySelector('[data-slot="skeleton"]')).toBeTruthy();
+  });
+
+  it("ErrorState retry button invokes onRetry", () => {
+    const onRetry = vi.fn();
+    render(<ErrorState onRetry={onRetry} />);
+    fireEvent.click(screen.getByRole("button", { name: "retry" }));
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/lib/chartTheme.test.ts
+++ b/frontend/src/lib/chartTheme.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { chartTheme } from "./chartTheme";
+
+describe("chartTheme", () => {
+  it("exposes semantic series colors as CSS var references", () => {
+    expect(chartTheme.gain).toBe("var(--color-gain)");
+    expect(chartTheme.loss).toBe("var(--color-loss)");
+  });
+  it("exposes an ordered categorical series palette", () => {
+    expect(Array.isArray(chartTheme.series)).toBe(true);
+    expect(chartTheme.series.length).toBeGreaterThanOrEqual(5);
+    expect(chartTheme.series[0]).toBe("var(--color-chart-1)");
+  });
+  it("exposes grid and tooltip styles bound to tokens", () => {
+    expect(chartTheme.grid.stroke).toBe("var(--color-surface-border)");
+    expect(chartTheme.tooltip.background).toBe("var(--color-surface)");
+  });
+});

--- a/frontend/src/lib/chartTheme.ts
+++ b/frontend/src/lib/chartTheme.ts
@@ -1,0 +1,18 @@
+export const chartTheme = {
+  gain: "var(--color-gain)",
+  loss: "var(--color-loss)",
+  neutral: "var(--color-neutral)",
+  series: [
+    "var(--color-chart-1)",
+    "var(--color-chart-2)",
+    "var(--color-chart-3)",
+    "var(--color-chart-4)",
+    "var(--color-chart-5)",
+  ],
+  grid: { stroke: "var(--color-surface-border)" },
+  tooltip: {
+    background: "var(--color-surface)",
+    border: "var(--color-surface-border)",
+    text: "var(--color-foreground)",
+  },
+} as const;

--- a/frontend/src/lib/format.test.ts
+++ b/frontend/src/lib/format.test.ts
@@ -14,7 +14,12 @@ describe("formatCurrency", () => {
   it("renders negatives with sign before the prefix", () => {
     expect(formatCurrency(-2300, "TWD")).toBe("-NT$2,300");
   });
-  it("rounds to whole units", () => {
-    expect(formatCurrency(1234.56, "TWD")).toBe("NT$1,235");
+  it("keeps up to two fraction digits so currency cents survive", () => {
+    expect(formatCurrency(1234.56, "TWD")).toBe("NT$1,234.56");
+    expect(formatCurrency(1000, "USD")).toBe("$1,000");
+  });
+  it("falls back to the currency code for unmapped currencies", () => {
+    expect(formatCurrency(1000, "EUR")).toBe("EUR 1,000");
+    expect(formatCurrency(-50.5, "JPY")).toBe("-JPY 50.5");
   });
 });

--- a/frontend/src/lib/format.test.ts
+++ b/frontend/src/lib/format.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { formatCurrency } from "./format";
+
+describe("formatCurrency", () => {
+  it("prefixes TWD with NT$", () => {
+    expect(formatCurrency(1284500, "TWD")).toBe("NT$1,284,500");
+  });
+  it("prefixes USD with $", () => {
+    expect(formatCurrency(1000, "USD")).toBe("$1,000");
+  });
+  it("defaults currency to TWD", () => {
+    expect(formatCurrency(500)).toBe("NT$500");
+  });
+  it("renders negatives with sign before the prefix", () => {
+    expect(formatCurrency(-2300, "TWD")).toBe("-NT$2,300");
+  });
+  it("rounds to whole units", () => {
+    expect(formatCurrency(1234.56, "TWD")).toBe("NT$1,235");
+  });
+});

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -1,9 +1,11 @@
 export function formatCurrency(value: number, currency: string = "TWD"): string {
-  const prefix = currency === "TWD" ? "NT$" : currency === "USD" ? "$" : "";
+  const symbol = currency === "TWD" ? "NT$" : currency === "USD" ? "$" : null;
   const sign = value < 0 ? "-" : "";
   const abs = Math.abs(value).toLocaleString("zh-TW", {
     minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
+    maximumFractionDigits: 2,
   });
-  return `${sign}${prefix}${abs}`;
+  // Known currencies get a glyph prefix; anything else keeps its code so the
+  // amount is never rendered without a currency indicator.
+  return symbol ? `${sign}${symbol}${abs}` : `${sign}${currency} ${abs}`;
 }

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -1,0 +1,9 @@
+export function formatCurrency(value: number, currency: string = "TWD"): string {
+  const prefix = currency === "TWD" ? "NT$" : currency === "USD" ? "$" : "";
+  const sign = value < 0 ? "-" : "";
+  const abs = Math.abs(value).toLocaleString("zh-TW", {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  });
+  return `${sign}${prefix}${abs}`;
+}

--- a/frontend/src/providers/ThemeProvider.tsx
+++ b/frontend/src/providers/ThemeProvider.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  return (
+    <NextThemesProvider
+      attribute="class"
+      defaultTheme="system"
+      enableSystem
+      disableTransitionOnChange
+    >
+      {children}
+    </NextThemesProvider>
+  );
+}

--- a/frontend/src/providers/ZenModeProvider.test.tsx
+++ b/frontend/src/providers/ZenModeProvider.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ZenModeProvider, useZenMode } from "./ZenModeProvider";
+
+function Probe() {
+  const { zen, toggleZen } = useZenMode();
+  return <button onClick={toggleZen}>{zen ? "on" : "off"}</button>;
+}
+
+describe("ZenModeProvider", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("defaults to off when storage empty", () => {
+    render(
+      <ZenModeProvider>
+        <Probe />
+      </ZenModeProvider>
+    );
+    expect(screen.getByRole("button").textContent).toBe("off");
+  });
+
+  it("toggles and persists to localStorage", () => {
+    render(
+      <ZenModeProvider>
+        <Probe />
+      </ZenModeProvider>
+    );
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.getByRole("button").textContent).toBe("on");
+    expect(localStorage.getItem("zen-mode")).toBe("true");
+  });
+
+  it("hydrates from existing localStorage value", () => {
+    localStorage.setItem("zen-mode", "true");
+    render(
+      <ZenModeProvider>
+        <Probe />
+      </ZenModeProvider>
+    );
+    expect(screen.getByRole("button").textContent).toBe("on");
+  });
+});

--- a/frontend/src/providers/ZenModeProvider.tsx
+++ b/frontend/src/providers/ZenModeProvider.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState } from "react";
+
+const STORAGE_KEY = "zen-mode";
+
+type ZenModeContextValue = { zen: boolean; toggleZen: () => void };
+
+const ZenModeContext = createContext<ZenModeContextValue | null>(null);
+
+export function ZenModeProvider({ children }: { children: React.ReactNode }) {
+  const [zen, setZen] = useState(false);
+
+  useEffect(() => {
+    try {
+      if (localStorage.getItem(STORAGE_KEY) === "true") setZen(true);
+    } catch {
+      // localStorage unavailable — stay default off
+    }
+  }, []);
+
+  const toggleZen = () =>
+    setZen((prev) => {
+      const next = !prev;
+      try {
+        localStorage.setItem(STORAGE_KEY, String(next));
+      } catch {
+        // ignore persistence failure
+      }
+      return next;
+    });
+
+  return (
+    <ZenModeContext.Provider value={{ zen, toggleZen }}>
+      {children}
+    </ZenModeContext.Provider>
+  );
+}
+
+export function useZenMode(): ZenModeContextValue {
+  const ctx = useContext(ZenModeContext);
+  if (!ctx) throw new Error("useZenMode must be used within ZenModeProvider");
+  return ctx;
+}

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,7 +1,23 @@
 import "@testing-library/jest-dom/vitest";
 import { cleanup } from "@testing-library/react";
-import { afterAll, afterEach, beforeAll } from "vitest";
+import { afterAll, afterEach, beforeAll, vi } from "vitest";
 import { server } from "./server";
+
+if (!window.matchMedia) {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }),
+  });
+}
 
 beforeAll(() => server.listen({ onUnhandledRequest: "warn" }));
 afterEach(() => {

--- a/frontend/src/test/utils.tsx
+++ b/frontend/src/test/utils.tsx
@@ -3,6 +3,8 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { NextIntlClientProvider } from "next-intl";
 import { type ReactElement, type ReactNode } from "react";
 import messages from "../../messages/en.json";
+import { ThemeProvider } from "@/providers/ThemeProvider";
+import { ZenModeProvider } from "@/providers/ZenModeProvider";
 
 export function createTestQueryClient() {
   return new QueryClient({
@@ -24,7 +26,9 @@ function AllProviders({ children }: ProvidersProps) {
   return (
     <QueryClientProvider client={queryClient}>
       <NextIntlClientProvider locale="en" messages={messages}>
-        {children}
+        <ThemeProvider>
+          <ZenModeProvider>{children}</ZenModeProvider>
+        </ThemeProvider>
       </NextIntlClientProvider>
     </QueryClientProvider>
   );

--- a/frontend/src/types/analytics.ts
+++ b/frontend/src/types/analytics.ts
@@ -86,19 +86,6 @@ export function getTimeRangeOptions() {
 }
 
 /**
- * 格式化金額（加上千分位）
- */
-export function formatCurrency(
-  amount: number,
-  currency: string = "TWD"
-): string {
-  return `${currency} ${amount.toLocaleString("zh-TW", {
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
-  })}`;
-}
-
-/**
  * 格式化百分比
  */
 export function formatPercentage(value: number): string {

--- a/frontend/src/types/holding.ts
+++ b/frontend/src/types/holding.ts
@@ -69,20 +69,6 @@ export const holdingFiltersSchema = z.object({
 // ==================== 輔助函式 ====================
 
 /**
- * 格式化貨幣顯示
- * @param value 金額
- * @param currency 貨幣代碼
- * @returns 格式化後的字串
- */
-export function formatCurrency(value: number, currency: string): string {
-  const prefix = currency === "TWD" ? "NT$" : currency === "USD" ? "$" : "";
-  return `${prefix} ${value.toLocaleString("zh-TW", {
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 2,
-  })}`;
-}
-
-/**
  * 格式化百分比顯示
  * @param value 百分比數值
  * @returns 格式化後的字串


### PR DESCRIPTION
## 摘要

Closes #108

為 asset-manager 導入 Ghostfolio 風格的視覺基礎與可重用設計系統,**純前端、不改動結構或資料流**。這是 Ghostfolio 對齊計畫(Foundation-first A→B→C→D→E)的第一階段 A。

## 變更內容

- **設計 token**:`globals.css` 新增語意化 token(`gain`/`loss`/`neutral`/`surface`,亮/暗色,OKLCH)
- **圖表主題**:新增 `src/lib/chartTheme.ts`,由 token 衍生;`AssetTrendChart`、`AssetAllocationChart`、`MonthlyExpenseChart` 移除硬編碼色
- **主題切換**:接線既有但未使用的 `next-themes`(`ThemeProvider` + `ThemeToggle`),`<html suppressHydrationWarning>`
- **Zen Mode**:`ZenModeProvider`(localStorage 持久化)+ `<Money>` 元件遮蔽絕對金額(保留百分比)+ `ZenModeToggle`,外殼加入兩個切換鈕
- **共用狀態元件**:`EmptyState` / `LoadingState` / `ErrorState`(含 `states` i18n,en + zh-TW),取代各頁臨時寫法
- **統一金額格式**:新增 `src/lib/format.ts`,移除 `types/holding.ts`、`types/analytics.ts` 兩份分歧的 `formatCurrency`
- **測試基礎**:`renderWithProviders` 補上 Theme/Zen Provider,`test/setup.ts` 全域 mock `matchMedia`

## 測試

- `pnpm vitest run`:18 檔 / 64 測試全綠(含新增 format、chartTheme、Money、ZenModeProvider、ThemeToggle、ZenModeToggle、states 測試)
- `pnpm build`:成功,14 條路由皆通過型別檢查

## Review 第 1 輪修正(已套用)

- **金額符號回歸修正**:`lib/format.ts` 對未對應的幣別(非 TWD/USD)改以「幣別代碼 + 空格」前綴呈現,不再裸數字;`analytics` 動態幣別路徑已涵蓋。
- **小數精度回歸修正**:格式化保留最多 2 位小數(回復原 holding 格式行為,USD 角分不再被截掉)。
- **Zen Mode 補全**:`analytics/page.tsx` 16 處金額全數改用 `<Money>`,Zen 模式現可遮蔽分析頁所有金額。

## 刻意保留 / 後續

- 金額符號與數字間的空格刻意移除(舊 `"NT$ 1,234"` → 新 `"NT$1,234"`),為本次設計語言的一致樣式決定。
- `analytics/page.tsx` 兩處漲跌色(紅=漲、綠=跌的台股慣例)**刻意未** token 化:現行語意 token 為西方慣例(綠=gain),強行替換會反轉既有 UX。漲跌色慣例與 token 的調和屬獨立設計議題,留待後續處理。
- 後端、新分析功能(報酬率引擎、多維配置、持倉明細、X-ray、FIRE)屬子專案 B–E,不在本 PR 範圍。
- 規格 `docs/superpowers/specs/2026-05-18-design-system-shell-design.md`、計畫 `docs/superpowers/plans/2026-05-18-design-system-shell.md`(docs/ 已 gitignore,未入庫)。
