### PR TITLE
feat: 完整實作 dark mode（移除硬編碼淺色樣式）

### DIFF
--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,0 +1,9 @@
+allowBuilds:
+  '@parcel/watcher': true
+  '@swc/core': true
+  esbuild: true
+  msw: true
+  # sharp is an optional Next.js image-optimization dep with no prebuilt binary
+  # for this toolchain; it fails to build from source and next build works
+  # without it, so its build script is intentionally skipped.
+  sharp: false

--- a/frontend/src/app/analytics/page.tsx
+++ b/frontend/src/app/analytics/page.tsx
@@ -65,7 +65,7 @@ export default function AnalyticsPage() {
   return (
     <AppLayout title={t("title")} description={t("description")}>
       {/* Main Content */}
-      <div className="flex-1 p-4 md:p-6 bg-gray-50">
+      <div className="flex-1 p-4 md:p-6 bg-muted">
         <div className="flex flex-col gap-6">
           {/* 分析類型切換 */}
           <Tabs

--- a/frontend/src/app/cash-flows/page.tsx
+++ b/frontend/src/app/cash-flows/page.tsx
@@ -164,7 +164,7 @@ export default function CashFlowsPage() {
   return (
     <AppLayout title={t("title")} description={t("pageDescription")}>
       {/* Main Content */}
-      <div className="flex-1 p-4 md:p-6 bg-gray-50 space-y-6">
+      <div className="flex-1 p-4 md:p-6 bg-muted space-y-6">
         {/* 當月/當週每日收入/支出圖表 - 置於頁面最上方 */}
         <Card>
           <CardHeader>

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -125,7 +125,7 @@ export default function DashboardPage() {
   if (holdingsLoading || transactionsLoading) {
     return (
       <AppLayout title={t("title")} description={t("description")}>
-        <div className="flex-1 p-4 md:p-6 bg-gray-50">
+        <div className="flex-1 p-4 md:p-6 bg-muted">
           <div className="@container/main flex flex-1 flex-col gap-4 md:gap-6">
             {/* 統計卡片 Loading */}
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
@@ -175,7 +175,7 @@ export default function DashboardPage() {
   if (holdingsError || transactionsError) {
     return (
       <AppLayout title={t("title")} description={t("description")}>
-        <div className="flex-1 p-4 md:p-6 bg-gray-50">
+        <div className="flex-1 p-4 md:p-6 bg-muted">
           <Card>
             <CardContent className="pt-6">
               <div className="flex items-center gap-2 text-red-600">
@@ -195,16 +195,16 @@ export default function DashboardPage() {
   return (
     <AppLayout title={t("title")} description={t("description")}>
       {/* 內容區域 */}
-      <div className="flex-1 p-4 md:p-6 bg-gray-50">
+      <div className="flex-1 p-4 md:p-6 bg-muted">
         <div className="@container/main flex flex-1 flex-col gap-4 md:gap-6">
           {/* 過期價格警告 */}
           {stalePriceInfo && (
-            <Alert variant="default" className="border-amber-200 bg-amber-50">
-              <AlertTriangle className="h-4 w-4 text-amber-600" />
-              <AlertTitle className="text-amber-900">
+            <Alert variant="default" className="border-warning/30 bg-warning/10">
+              <AlertTriangle className="h-4 w-4 text-warning" />
+              <AlertTitle className="text-warning-foreground">
                 {t("stalePriceWarning")}
               </AlertTitle>
-              <AlertDescription className="text-amber-800">
+              <AlertDescription className="text-warning-foreground">
                 {t("stalePriceDescription")}
                 <br />
                 <span className="text-sm">

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -46,6 +46,8 @@
   --color-neutral: var(--neutral);
   --color-surface: var(--surface);
   --color-surface-border: var(--surface-border);
+  --color-warning: var(--warning);
+  --color-warning-foreground: var(--warning-foreground);
 }
 
 :root {
@@ -86,6 +88,8 @@
   --neutral: oklch(0.55 0 0);
   --surface: oklch(0.985 0 0);
   --surface-border: oklch(0.92 0 0);
+  --warning: oklch(0.62 0.15 65);
+  --warning-foreground: oklch(0.42 0.12 65);
 }
 
 .dark {
@@ -125,6 +129,8 @@
   --neutral: oklch(0.65 0 0);
   --surface: oklch(0.2 0.01 250);
   --surface-border: oklch(0.27 0.01 250);
+  --warning: oklch(0.8 0.15 75);
+  --warning-foreground: oklch(0.86 0.13 80);
 }
 
 @layer base {

--- a/frontend/src/app/holdings/page.tsx
+++ b/frontend/src/app/holdings/page.tsx
@@ -411,7 +411,7 @@ export default function HoldingsPage() {
   if (isLoading) {
     return (
       <AppLayout title={t("title")} description={t("description")}>
-        <div className="flex-1 p-4 md:p-6 bg-gray-50">
+        <div className="flex-1 p-4 md:p-6 bg-muted">
           <div className="flex items-center justify-center h-96">
             <Loading variant="page" size="lg" text={t("loadingHoldings")} />
           </div>
@@ -424,7 +424,7 @@ export default function HoldingsPage() {
   if (error) {
     return (
       <AppLayout title={t("title")} description={t("description")}>
-        <div className="flex-1 p-4 md:p-6 bg-gray-50">
+        <div className="flex-1 p-4 md:p-6 bg-muted">
           <div className="flex items-center justify-center h-96">
             <Card className="w-full max-w-md">
               <CardHeader>
@@ -455,7 +455,7 @@ export default function HoldingsPage() {
   return (
     <AppLayout title={t("title")} description={t("description")}>
       {/* Main Content */}
-      <div className="flex-1 p-4 md:p-6 bg-gray-50">
+      <div className="flex-1 p-4 md:p-6 bg-muted">
         <div className="flex flex-col gap-6">
           {/* 統計摘要卡片 */}
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">

--- a/frontend/src/app/notification/page.tsx
+++ b/frontend/src/app/notification/page.tsx
@@ -170,7 +170,7 @@ export default function NotificationPage() {
   if (isLoading) {
     return (
       <AppLayout title={t("title")} description={t("description")}>
-        <main className="flex-1 p-4 md:p-6 bg-gray-50">
+        <main className="flex-1 p-4 md:p-6 bg-muted">
           <Loading variant="page" size="lg" text={tCommon("loading")} />
         </main>
       </AppLayout>
@@ -179,7 +179,7 @@ export default function NotificationPage() {
 
   return (
     <AppLayout title={t("title")} description={t("description")}>
-      <div className="flex-1 p-4 md:p-6 bg-gray-50">
+      <div className="flex-1 p-4 md:p-6 bg-muted">
         <div className="flex flex-col gap-6">
           {/* Discord 設定和訂閱分期通知設定 - 並排顯示 */}
           <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -16,10 +16,10 @@ export default function Home() {
   }, [router]);
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-50">
+    <div className="flex min-h-screen items-center justify-center bg-muted">
       <div className="text-center">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-gray-900 mx-auto mb-4"></div>
-        <p className="text-gray-600">載入中...</p>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-foreground mx-auto mb-4"></div>
+        <p className="text-muted-foreground">載入中...</p>
       </div>
     </div>
   );

--- a/frontend/src/app/rebalance/page.tsx
+++ b/frontend/src/app/rebalance/page.tsx
@@ -33,7 +33,7 @@ export default function RebalancePage() {
   if (isLoading) {
     return (
       <AppLayout title={t("title")} description={t("description")}>
-        <div className="flex-1 p-4 md:p-6 bg-gray-50">
+        <div className="flex-1 p-4 md:p-6 bg-muted">
           <div className="flex items-center justify-center h-96">
             <Loading variant="page" size="lg" text={tCommon("loading")} />
           </div>
@@ -46,7 +46,7 @@ export default function RebalancePage() {
   if (error) {
     return (
       <AppLayout title={t("title")} description={t("description")}>
-        <div className="flex-1 p-4 md:p-6 bg-gray-50">
+        <div className="flex-1 p-4 md:p-6 bg-muted">
           <div className="flex items-center justify-center h-96">
             <Card className="w-full max-w-md">
               <CardHeader>
@@ -74,7 +74,7 @@ export default function RebalancePage() {
 
   return (
     <AppLayout title={t("title")} description={t("description")}>
-      <div className="flex-1 p-4 md:p-6 bg-gray-50">
+      <div className="flex-1 p-4 md:p-6 bg-muted">
         <div className="flex flex-col gap-6">
           {/* 摘要資訊 */}
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">

--- a/frontend/src/app/recurring/page.tsx
+++ b/frontend/src/app/recurring/page.tsx
@@ -276,7 +276,7 @@ export default function RecurringPage() {
   return (
     <AppLayout title={t("title")} description={t("description")}>
       {/* Main Content */}
-      <div className="flex-1 p-4 md:p-6 bg-gray-50">
+      <div className="flex-1 p-4 md:p-6 bg-muted">
         <div className="flex flex-col gap-6">
           {/* 統計卡片 */}
           <RecurringStatsCard

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -108,7 +108,7 @@ export default function SettingsPage() {
   if (isLoading) {
     return (
       <AppLayout title={t("title")} description={t("description")}>
-        <main className="flex-1 p-4 md:p-6 bg-gray-50">
+        <main className="flex-1 p-4 md:p-6 bg-muted">
           <Loading variant="page" size="lg" text={t("loadingSettings")} />
         </main>
       </AppLayout>
@@ -118,7 +118,7 @@ export default function SettingsPage() {
   return (
     <AppLayout title={t("title")} description={t("description")}>
       {/* Main Content */}
-      <div className="flex-1 p-4 md:p-6 bg-gray-50">
+      <div className="flex-1 p-4 md:p-6 bg-muted">
         <div className="flex flex-col gap-6">
           {/* 資產配置設定和匯率設定 - 並排顯示 */}
           <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">

--- a/frontend/src/app/transactions/page.tsx
+++ b/frontend/src/app/transactions/page.tsx
@@ -229,7 +229,7 @@ export default function TransactionsPage() {
   return (
     <AppLayout title={t("title")} description={t("description")}>
       {/* Main Content */}
-      <div className="flex-1 p-4 md:p-6 bg-gray-50 space-y-6">
+      <div className="flex-1 p-4 md:p-6 bg-muted space-y-6">
         {/* 上半部：Tab + 統計卡片 */}
         <div className="flex flex-col gap-6">
           {/* Tab 切換 */}
@@ -434,7 +434,7 @@ export default function TransactionsPage() {
                             ? "text-green-600"
                             : transaction.type === "dividend"
                             ? "text-blue-600"
-                            : "text-gray-600";
+                            : "text-muted-foreground";
 
                         return (
                           <TableRow key={transaction.id}>

--- a/frontend/src/app/user-management/page.tsx
+++ b/frontend/src/app/user-management/page.tsx
@@ -354,7 +354,7 @@ export default function UserManagementPage() {
   return (
     <AppLayout title={t("title")} description={t("description")}>
       {/* Main Content */}
-      <div className="flex-1 p-4 md:p-6 bg-gray-50">
+      <div className="flex-1 p-4 md:p-6 bg-muted">
         <div className="flex flex-col gap-6">
           {/* 分類管理 */}
           <CategoryManagement />

--- a/frontend/src/components/cash-flows/CashFlowCard.tsx
+++ b/frontend/src/components/cash-flows/CashFlowCard.tsx
@@ -36,7 +36,7 @@ const getCashFlowTypeColor = (type: CashFlowType) => {
     case CashFlowType.EXPENSE:
       return "bg-red-100 text-red-800";
     default:
-      return "bg-gray-100 text-gray-800";
+      return "bg-muted text-foreground";
   }
 };
 
@@ -121,7 +121,7 @@ export function CashFlowCard({
         </div>
 
         {/* 金額 */}
-        <div className="bg-gray-50 rounded-lg p-3 mb-3">
+        <div className="bg-muted rounded-lg p-3 mb-3">
           <div className="flex items-center justify-between">
             <div className="text-sm text-muted-foreground">金額</div>
             <div className="flex items-center gap-2">

--- a/frontend/src/components/cash-flows/CashFlowList.tsx
+++ b/frontend/src/components/cash-flows/CashFlowList.tsx
@@ -136,15 +136,15 @@ export function CashFlowList({ filters }: CashFlowListProps) {
                   TypeIcon = TrendingDown;
                   break;
                 case "transfer_in":
-                  typeColor = "text-gray-600";
+                  typeColor = "text-muted-foreground";
                   TypeIcon = ArrowDownToLine;
                   break;
                 case "transfer_out":
-                  typeColor = "text-gray-600";
+                  typeColor = "text-muted-foreground";
                   TypeIcon = ArrowUpFromLine;
                   break;
                 default:
-                  typeColor = "text-gray-600";
+                  typeColor = "text-muted-foreground";
                   TypeIcon = TrendingUp;
               }
 

--- a/frontend/src/components/cash-flows/CashFlowSummaryCard.tsx
+++ b/frontend/src/components/cash-flows/CashFlowSummaryCard.tsx
@@ -128,7 +128,7 @@ export function CashFlowSummaryCard({
           </CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="text-2xl font-bold text-gray-600">
+          <div className="text-2xl font-bold text-muted-foreground">
             {incomeRecords}
           </div>
           <p className="text-xs text-muted-foreground mt-1">
@@ -145,7 +145,7 @@ export function CashFlowSummaryCard({
           </CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="text-2xl font-bold text-gray-600">
+          <div className="text-2xl font-bold text-muted-foreground">
             {expenseRecords}
           </div>
           <p className="text-xs text-muted-foreground mt-1">
@@ -162,7 +162,7 @@ export function CashFlowSummaryCard({
           </CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="text-2xl font-bold text-gray-600">{totalRecords}</div>
+          <div className="text-2xl font-bold text-muted-foreground">{totalRecords}</div>
           <p className="text-xs text-muted-foreground mt-1">
             {t("totalRecordsDesc")}
           </p>

--- a/frontend/src/components/dashboard/Header.tsx
+++ b/frontend/src/components/dashboard/Header.tsx
@@ -31,7 +31,7 @@ export function Header({ userName = "使用者", onMenuClick }: HeaderProps) {
   };
 
   return (
-    <header className="bg-white border-b border-gray-200 sticky top-0 z-10">
+    <header className="bg-card border-b border-border sticky top-0 z-10">
       <div className="flex items-center justify-between px-6 py-4">
         {/* 左側：歡迎訊息 + 手機版選單按鈕 */}
         <div className="flex items-center gap-4">
@@ -47,10 +47,10 @@ export function Header({ userName = "使用者", onMenuClick }: HeaderProps) {
 
           {/* 歡迎訊息 */}
           <div>
-            <h1 className="text-xl font-bold text-gray-900">
+            <h1 className="text-xl font-bold text-foreground">
               歡迎回來, {userName}!
             </h1>
-            <p className="text-sm text-gray-600 hidden sm:block">
+            <p className="text-sm text-muted-foreground hidden sm:block">
               這是你今天的資產概況
             </p>
           </div>
@@ -60,12 +60,12 @@ export function Header({ userName = "使用者", onMenuClick }: HeaderProps) {
         <div className="flex items-center gap-3">
           {/* 搜尋按鈕 */}
           <Button variant="ghost" size="icon" className="hidden sm:flex">
-            <SearchIcon className="h-5 w-5 text-gray-600" />
+            <SearchIcon className="h-5 w-5 text-muted-foreground" />
           </Button>
 
           {/* 通知按鈕 */}
           <Button variant="ghost" size="icon" className="relative">
-            <BellIcon className="h-5 w-5 text-gray-600" />
+            <BellIcon className="h-5 w-5 text-muted-foreground" />
             {/* 通知小紅點 */}
             <span className="absolute top-2 right-2 w-2 h-2 bg-red-500 rounded-full"></span>
           </Button>
@@ -80,10 +80,10 @@ export function Header({ userName = "使用者", onMenuClick }: HeaderProps) {
                     {userName.charAt(0).toUpperCase()}
                   </AvatarFallback>
                 </Avatar>
-                <span className="hidden sm:inline text-sm font-medium text-gray-700">
+                <span className="hidden sm:inline text-sm font-medium text-muted-foreground">
                   {userName}
                 </span>
-                <ChevronDownIcon className="h-4 w-4 text-gray-600" />
+                <ChevronDownIcon className="h-4 w-4 text-muted-foreground" />
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="w-56">

--- a/frontend/src/components/dashboard/RecentTransactions.tsx
+++ b/frontend/src/components/dashboard/RecentTransactions.tsx
@@ -78,9 +78,9 @@ export function RecentTransactions({ transactions }: RecentTransactionsProps) {
                       }`}
                     >
                       {isBuy ? (
-                        <ArrowDownIcon className="h-3 w-3 text-red-600" />
+                        <ArrowDownIcon className="h-3 w-3 text-loss" />
                       ) : (
-                        <ArrowUpIcon className="h-3 w-3 text-green-600" />
+                        <ArrowUpIcon className="h-3 w-3 text-gain" />
                       )}
                     </div>
 

--- a/frontend/src/components/dashboard/RecurringStatsCard.tsx
+++ b/frontend/src/components/dashboard/RecurringStatsCard.tsx
@@ -205,7 +205,7 @@ export function RecurringStatsCard({
         {/* 提醒 */}
         {(expiringSubscriptions.length > 0 ||
           completingInstallments.length > 0) && (
-          <div className="flex items-start gap-2 rounded-lg bg-amber-50 p-3 text-amber-900">
+          <div className="flex items-start gap-2 rounded-lg bg-warning/10 p-3 text-warning-foreground">
             <AlertCircleIcon className="h-4 w-4 mt-0.5 shrink-0" />
             <div className="text-xs space-y-1">
               {expiringSubscriptions.length > 0 && (

--- a/frontend/src/components/dashboard/StatCard.tsx
+++ b/frontend/src/components/dashboard/StatCard.tsx
@@ -32,8 +32,8 @@ export function StatCard({ title, value, change, description }: StatCardProps) {
             variant="outline"
             className={`gap-1 ${
               isPositive
-                ? "bg-green-50 text-green-700 border-green-200"
-                : "bg-red-50 text-red-700 border-red-200"
+                ? "bg-gain/10 text-gain border-gain/30"
+                : "bg-loss/10 text-loss border-loss/30"
             }`}
           >
             {isPositive ? (

--- a/frontend/src/components/examples/TransactionExample.tsx
+++ b/frontend/src/components/examples/TransactionExample.tsx
@@ -67,7 +67,7 @@ export function TransactionExample() {
         <button
           onClick={handleCreateTestTransaction}
           disabled={createMutation.isPending}
-          className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 disabled:bg-gray-400"
+          className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 disabled:bg-muted"
         >
           {createMutation.isPending ? "建立中..." : "建立測試交易"}
         </button>
@@ -81,15 +81,15 @@ export function TransactionExample() {
           {data?.map((transaction) => (
             <div
               key={transaction.id}
-              className="p-3 border rounded bg-gray-50"
+              className="p-3 border rounded bg-muted"
             >
               <div className="flex justify-between">
                 <span className="font-medium">{transaction.name}</span>
-                <span className="text-sm text-gray-500">
+                <span className="text-sm text-muted-foreground">
                   {transaction.symbol}
                 </span>
               </div>
-              <div className="text-sm text-gray-600">
+              <div className="text-sm text-muted-foreground">
                 {transaction.type} | 數量: {transaction.quantity} | 價格:{" "}
                 {transaction.price}
               </div>

--- a/frontend/src/components/transactions/TransactionCard.tsx
+++ b/frontend/src/components/transactions/TransactionCard.tsx
@@ -40,9 +40,9 @@ const getTransactionTypeColor = (type: TransactionType) => {
     case TransactionType.DIVIDEND:
       return "bg-blue-100 text-blue-800";
     case TransactionType.FEE:
-      return "bg-gray-100 text-gray-800";
+      return "bg-muted text-foreground";
     default:
-      return "bg-gray-100 text-gray-800";
+      return "bg-muted text-foreground";
   }
 };
 
@@ -60,7 +60,7 @@ const getAssetTypeColor = (assetType: AssetType) => {
     case AssetType.CASH:
       return "bg-emerald-100 text-emerald-800";
     default:
-      return "bg-gray-100 text-gray-800";
+      return "bg-muted text-foreground";
   }
 };
 
@@ -150,7 +150,7 @@ export function TransactionCard({
         </div>
 
         {/* 總金額 */}
-        <div className="bg-gray-50 rounded-lg p-3 mb-3">
+        <div className="bg-muted rounded-lg p-3 mb-3">
           <div className="flex items-center justify-between">
             <div className="text-sm text-muted-foreground">總金額</div>
             <div className="flex items-center gap-2">

--- a/frontend/src/components/user-management/CreditCardGroupForm.tsx
+++ b/frontend/src/components/user-management/CreditCardGroupForm.tsx
@@ -182,7 +182,7 @@ export function CreditCardGroupForm({
                       checked={isSelected}
                       disabled={isDisabled}
                       onChange={() => handleCardToggle(card.id)}
-                      className="h-4 w-4 rounded border-gray-300"
+                      className="h-4 w-4 rounded border-border"
                     />
                     <div className="flex-1">
                       <div className="flex items-center gap-2">

--- a/frontend/src/lib/mock-data.ts
+++ b/frontend/src/lib/mock-data.ts
@@ -451,7 +451,7 @@ export const transactionTypeColors: Record<Transaction['type'], string> = {
   buy: 'bg-blue-100 text-blue-800',
   sell: 'bg-red-100 text-red-800',
   dividend: 'bg-green-100 text-green-800',
-  fee: 'bg-gray-100 text-gray-800',
+  fee: 'bg-muted text-foreground',
 };
 
 // 績效分析資料

--- a/frontend/src/test/no-hardcoded-colors.test.ts
+++ b/frontend/src/test/no-hardcoded-colors.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+// Dark mode relies on semantic design tokens. Hardcoded light Tailwind
+// utilities (bg-white, bg-gray-N, text-gray-N, border-gray-N, text-black,
+// arbitrary hex utilities) do not adapt to the dark theme. This guard fails
+// if any reappear so the regression cannot creep back in.
+const BANNED =
+  /\b(?:bg-white|text-black|(?:bg|text|border)-gray-\d{2,3}|(?:bg|text|border)-\[#[0-9a-fA-F]{3,8}\])\b/;
+
+// Documented, deliberate exceptions (see issue #25 / PR #119).
+const EXCEPT = new Set<string>([
+  // Arbitrary selectors that neutralize Recharts' own #fff/#ccc defaults.
+  "src/components/ui/chart.tsx",
+]);
+
+const ROOT = join(__dirname, "..");
+
+function walk(dir: string, acc: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      walk(full, acc);
+    } else if (/\.tsx?$/.test(entry) && !/\.test\.tsx?$/.test(entry)) {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+describe("no hardcoded light colors (dark-mode guard)", () => {
+  it("every source file uses semantic tokens, not hardcoded light classes", () => {
+    const violations: string[] = [];
+    for (const file of walk(ROOT)) {
+      const rel = file.slice(file.indexOf("src/"));
+      if (EXCEPT.has(rel)) continue;
+      readFileSync(file, "utf8")
+        .split("\n")
+        .forEach((line, i) => {
+          if (BANNED.test(line)) {
+            violations.push(`${rel}:${i + 1}  ${line.trim().slice(0, 100)}`);
+          }
+        });
+    }
+    expect(violations, `Hardcoded light classes found:\n${violations.join("\n")}`).toEqual([]);
+  });
+});

--- a/frontend/src/test/no-hardcoded-colors.test.ts
+++ b/frontend/src/test/no-hardcoded-colors.test.ts
@@ -6,8 +6,12 @@ import { join } from "node:path";
 // utilities (bg-white, bg-gray-N, text-gray-N, border-gray-N, text-black,
 // arbitrary hex utilities) do not adapt to the dark theme. This guard fails
 // if any reappear so the regression cannot creep back in.
+// Trailing boundary is a negative lookahead, not \b: the arbitrary-hex
+// branch ends in "]", a non-word char, so \b after it could never match
+// (it would require a following word char, but real code has whitespace or
+// a quote there). (?![\w-]) lets every branch terminate correctly.
 const BANNED =
-  /\b(?:bg-white|text-black|(?:bg|text|border)-gray-\d{2,3}|(?:bg|text|border)-\[#[0-9a-fA-F]{3,8}\])\b/;
+  /\b(?:bg-white|text-black|(?:bg|text|border)-gray-\d{2,3}|(?:bg|text|border)-\[#[0-9a-fA-F]{3,8}\])(?![\w-])/;
 
 // Documented, deliberate exceptions (see issue #25 / PR #119).
 const EXCEPT = new Set<string>([
@@ -44,5 +48,33 @@ describe("no hardcoded light colors (dark-mode guard)", () => {
         });
     }
     expect(violations, `Hardcoded light classes found:\n${violations.join("\n")}`).toEqual([]);
+  });
+
+  it("BANNED regex actually catches every hardcoded form", () => {
+    for (const bad of [
+      'className="bg-white"',
+      "text-black ",
+      "bg-gray-50",
+      "bg-gray-100",
+      "text-gray-700",
+      "border-gray-300",
+      "bg-[#fff]",
+      'text-[#abcdef]',
+      "border-[#ccc]/50",
+    ]) {
+      expect(BANNED.test(bad), `should flag: ${bad}`).toBe(true);
+    }
+    for (const ok of [
+      "bg-card",
+      "bg-muted",
+      "text-foreground",
+      "text-muted-foreground",
+      "border-border",
+      "bg-gain/10",
+      "text-warning",
+      "bg-grayish-thing", // not a gray-NN utility
+    ]) {
+      expect(BANNED.test(ok), `should not flag: ${ok}`).toBe(false);
+    }
   });
 });

--- a/frontend/src/types/cash-flow.ts
+++ b/frontend/src/types/cash-flow.ts
@@ -391,8 +391,8 @@ export function getCashFlowTypeColor(cashFlowType: CashFlowType): string {
   const colors: Record<CashFlowType, string> = {
     [CashFlowType.INCOME]: "text-green-600",
     [CashFlowType.EXPENSE]: "text-red-600",
-    [CashFlowType.TRANSFER_IN]: "text-gray-600",
-    [CashFlowType.TRANSFER_OUT]: "text-gray-600",
+    [CashFlowType.TRANSFER_IN]: "text-muted-foreground",
+    [CashFlowType.TRANSFER_OUT]: "text-muted-foreground",
   };
   return colors[cashFlowType];
 }
@@ -405,8 +405,8 @@ export function getCashFlowTypeBgColor(cashFlowType: CashFlowType): string {
   const colors: Record<CashFlowType, string> = {
     [CashFlowType.INCOME]: "bg-red-100",
     [CashFlowType.EXPENSE]: "bg-green-100",
-    [CashFlowType.TRANSFER_IN]: "bg-gray-100",
-    [CashFlowType.TRANSFER_OUT]: "bg-gray-100",
+    [CashFlowType.TRANSFER_IN]: "bg-muted",
+    [CashFlowType.TRANSFER_OUT]: "bg-muted",
   };
   return colors[cashFlowType];
 }


### PR DESCRIPTION
## 摘要

Closes #25

承接子專案 A(PR #119)的設計 token 基礎,移除散落於約 24 個檔案的硬編碼淺色 Tailwind class,使所有頁面在 light 與 dark 兩種模式下皆正確顯示。純前端、不改動結構或資料流。

## 變更內容

- **新增 `--warning` 語意 token**:`globals.css` `@theme` + `:root` + `.dark`(亮/暗值),供警示區塊使用。
- **token 化替換**(`refactor` commit,24 檔):
  - `bg-white` → `bg-card`;`bg-gray-50/100/200` → `bg-muted`
  - `text-gray-800/900` → `text-foreground`;`text-gray-400/500/600/700` → `text-muted-foreground`
  - `border-gray-*` → `border-border`;`border-gray-900`(spinner)→ `border-foreground`
  - 涵蓋 11 個頁面 wrapper、`dashboard/Header.tsx`、交易/現金流元件、`lib/mock-data.ts`、`types/cash-flow.ts` 色彩對應表
- **Severity B 語意色**:`StatCard`(漲跌 badge → `gain`/`loss`)、`RecentTransactions`(箭頭 → `gain`/`loss`)、`dashboard/page.tsx` 與 `RecurringStatsCard` 警示區塊 → `warning` token。
- **回歸防護測試**:新增 `src/test/no-hardcoded-colors.test.ts`,掃描 `src/` 禁止 `bg-white`/`bg-gray-*`/`text-gray-*`/`border-gray-*`/任意 hex utility 再次出現(`chart.tsx` 為已記錄例外)。

## 測試

- `pnpm vitest run`:19 檔 / 65 測試全綠(含新 guard 測試)
- `pnpm build`:成功
- Playwright 實測:dashboard、transactions 於 dark 下一致無白底;cash-flows 於 light 下無回歸

## 前置 commit 說明

- `chore(frontend): allow build scripts via pnpm-workspace.yaml for pnpm 11`:此環境使用 pnpm 11,build script 允許清單需置於 `pnpm-workspace.yaml`(`package.json` 的 `pnpm.onlyBuiltDependencies` 僅 pnpm 10 適用)。此 commit 為跑得起 dev server 做視覺驗證的前置條件,故隨本 PR 一併提交。

## 不在範圍內

- `analytics/page.tsx` 兩處台股慣例漲跌色硬編碼(紅=漲;與西方 token 衝突,另案處理)
- raw `text-blue-*` 等強調色(對比可接受,非 dark 破壞點)
- 後端與資料流變更