### PR TITLE
docs: 以實際專案說明取代前端 boilerplate README

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,36 +1,110 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Asset Manager — Frontend
+
+The web client for Asset Manager, a personal finance system for tracking investment portfolios, cash flows, subscriptions, installments, and financial analytics. Built with the Next.js App Router, it talks to the Go/Gin backend API and renders dashboards, holdings, analytics, and rebalancing views.
+
+Primary UI language is Traditional Chinese (zh-TW) with English as a fallback.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Features](#features)
+- [Getting Started](#getting-started)
+- [Scripts](#scripts)
+- [Configuration](#configuration)
+- [Design System](#design-system)
+- [Project Structure](#project-structure)
+- [Testing](#testing)
+- [Contributing](#contributing)
+
+## Overview
+
+This package is the presentation layer of the Asset Manager monorepo. Data is fetched from the backend via the API client in `src/lib/` using TanStack Query; forms use react-hook-form with Zod validation; charts are rendered with Recharts. Internationalisation is handled by next-intl with message catalogs in `messages/`.
+
+## Features
+
+- **Dashboard** — portfolio value, asset trend, and allocation at a glance
+- **Holdings** — positions by asset type with FIFO cost-basis P&L
+- **Analytics** — realized and unrealized P&L breakdowns over selectable time ranges
+- **Cash flows** — income/expense tracking with daily, weekly, and monthly views
+- **Rebalance** — allocation drift detection against target weights
+- **Recurring** — subscription and installment management
+- **Zen Mode** — one-tap toggle that masks all absolute monetary amounts (percentages stay visible) for screenshots and privacy
+- **Light/Dark theme** — system-aware theme switching via next-themes
+- **i18n** — full zh-TW and en translations via next-intl
 
 ## Getting Started
 
-First, run the development server:
+Prerequisites: Node.js 20+ and pnpm.
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
+pnpm install
 pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+The dev server runs on [http://localhost:3001](http://localhost:3001). Point it at a running backend via `NEXT_PUBLIC_API_URL` (see [Configuration](#configuration)).
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Scripts
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+| Command | Purpose |
+|---------|---------|
+| `pnpm dev` | Start the dev server on port 3001 |
+| `pnpm build` | Production build (also type-checks app code) |
+| `pnpm start` | Serve the production build |
+| `pnpm test` | Run the Vitest unit/component suite |
+| `pnpm test:watch` | Vitest in watch mode |
+| `pnpm test:coverage` | Vitest with coverage report |
+| `pnpm test:e2e` | Playwright BDD end-to-end tests |
+| `pnpm tsc --noEmit` | Type-check |
 
-## Learn More
+## Configuration
 
-To learn more about Next.js, take a look at the following resources:
+Frontend config lives in `.env.local`:
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+| Variable | Description |
+|----------|-------------|
+| `NEXT_PUBLIC_API_URL` | Base URL of the backend API |
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+See the repository root `.env.template` for the full set of backend variables.
 
-## Deploy on Vercel
+## Design System
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+The design foundation (sub-project A) provides a reusable, token-driven base:
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+- **Semantic design tokens** — `src/app/globals.css` defines color/space/typography tokens including finance-semantic `gain`/`loss`/`neutral` and `surface`, with full light and dark value sets (OKLCH, Tailwind 4 `@theme`).
+- **Chart theme** — `src/lib/chartTheme.ts` derives all chart colors, grid, and tooltip styles from the tokens, so charts stay consistent across themes.
+- **Theming** — `src/providers/ThemeProvider.tsx` wires next-themes; `ThemeToggle` in the app shell switches light/dark.
+- **Zen Mode** — `src/providers/ZenModeProvider.tsx` holds a localStorage-persisted flag; the `<Money>` component (`src/components/common/Money.tsx`) renders currency and masks it when Zen is active. `ZenModeToggle` lives in the shell.
+- **Shared state components** — `src/components/ui/states/` provides `EmptyState`, `LoadingState`, and `ErrorState` (with retry), backed by the `states` i18n namespace.
+- **Unified formatting** — `src/lib/format.ts` is the single `formatCurrency` implementation (glyph prefix for TWD/USD, currency-code fallback otherwise).
+
+Subsequent phases (returns engine, multi-dimensional allocation, holdings detail pages, X-ray rules, FIRE projection) build on this foundation.
+
+## Project Structure
+
+```text
+frontend/
+├── src/
+│   ├── app/              # App Router pages (dashboard, holdings, analytics, ...)
+│   ├── components/       # UI components (shadcn/ui + Radix), charts, dialogs
+│   │   ├── common/       # Money, ThemeToggle, ZenModeToggle, LanguageSwitcher
+│   │   ├── ui/states/    # Shared Empty/Loading/Error states
+│   │   └── layout/       # App shell
+│   ├── providers/        # Theme, ZenMode, Query, Auth, Locale providers
+│   ├── hooks/            # TanStack Query data hooks
+│   ├── lib/              # API client, format, chartTheme
+│   └── test/             # Vitest setup and provider-aware render utils
+├── messages/             # next-intl catalogs (en.json, zh-TW.json)
+└── package.json
+```
+
+## Testing
+
+Unit and component tests use Vitest with jsdom and MSW for API mocking. `src/test/utils.tsx` exposes `renderWithProviders` (wraps Query, next-intl, Theme, and Zen providers); `src/test/setup.ts` registers jest-dom matchers and a global `matchMedia` mock. End-to-end tests use Playwright BDD (`pnpm test:e2e`).
+
+```bash
+pnpm test
+```
+
+## Contributing
+
+Branches follow the `issues/<N>` convention and target `dev` via pull request. Run `pnpm test` and `pnpm build` before opening a PR. Commit messages use a `type(scope): summary` style with no co-author trailers, matching the existing history.


### PR DESCRIPTION
## 摘要

`frontend/README.md` 原為 `create-next-app` 的預設 boilerplate。本 PR 以反映實際專案的說明取代之。

## 變更內容

- 專案概述、功能列表(含子專案 A 設計系統:tokens、theming、Zen Mode、共用狀態元件)
- Getting Started(Node 20+ / pnpm,dev server 在 3001)
- scripts 表、`NEXT_PUBLIC_API_URL` 設定
- Design System 章節(tokens / chartTheme / ThemeProvider / ZenModeProvider / 共用狀態 / 統一 formatCurrency)
- 專案結構、測試(Vitest + jsdom + MSW、`renderWithProviders`)、貢獻流程

## 範圍

純文件,無程式碼或設定變更。內容對應已合併的子專案 A(PR #119)與 dark mode 完整化(PR #120)現況。