### PR TITLE
chore: gitignore doc/ 與 docs/ 一致

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ yarn-error.log*
 openspec/
 
 # Planning docs
+doc/
 docs/
 note/
 


### PR DESCRIPTION
## 摘要

`doc/` 目錄存放本地規劃/封存筆記(從未進版控,無 git 歷史),與已被忽略的 `docs/` 同性質。將 `doc/` 加入 `.gitignore`,消除其長期以 untracked 出現的雜訊,並與 `docs/` 規則保持一致。

## 變更

- `.gitignore`:於 Planning docs 區塊新增 `doc/`

純設定,無程式碼變更。