### PR TITLE
feat: MCP agent 存取 Phase 1（唯讀工具 + 稽核）

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -19,7 +19,7 @@ NC     := \033[0m # No Color
 # Go 工具路徑
 GOTESTSUM := ./scripts/run-tests.sh
 
-.PHONY: help install test test-verbose test-unit test-integration test-bdd test-coverage test-watch migrate-up migrate-down migrate-create run build clean db-create db-drop seed seed-clean snapshot swagger swagger-check
+.PHONY: help install test test-verbose test-unit test-integration test-bdd test-coverage test-watch migrate-up migrate-down migrate-create run build mcp-build mcp-run clean db-create db-drop seed seed-clean snapshot swagger swagger-check
 
 # 顯示幫助訊息
 help:
@@ -159,6 +159,16 @@ build:
 	@echo "Building application..."
 	go build -o bin/api cmd/api/main.go
 	@echo "Build complete! Binary: bin/api"
+
+# 編譯 MCP server
+mcp-build:
+	@echo "Building MCP server..."
+	go build -o bin/mcp ./cmd/mcp
+	@echo "Build complete! Binary: bin/mcp"
+
+# 執行 MCP server（stdio，供 AI client 設定使用）
+mcp-run:
+	go run ./cmd/mcp
 
 # 清理編譯產物
 clean:

--- a/backend/cmd/mcp/README.md
+++ b/backend/cmd/mcp/README.md
@@ -1,0 +1,58 @@
+# MCP Server (Phase 1 — read-only)
+
+An in-process Model Context Protocol server that lets AI agents read portfolio
+data. It speaks MCP over **stdio** and reuses the same database and service
+layer as the API (no HTTP, no API keys). **Phase 1 is read-only** — there are
+no write tools (creating/updating/deleting transactions or reconciliation is
+Phase 2 and intentionally unavailable).
+
+## Tools
+
+| Tool | Arguments | Description |
+|------|-----------|-------------|
+| `get_holdings` | — | All holdings: quantity, avg cost, market value, unrealized P&L |
+| `get_holding` | `symbol` | A single holding by symbol |
+| `list_transactions` | `from?` `to?` (YYYY-MM-DD), `type?`, `symbol?`, `limit?` | Filtered transactions |
+| `get_transaction` | `id` (UUID) | A single transaction |
+| `get_analytics` | `range?` (`week`\|`month`\|`quarter`\|`year`\|`all`, default `all`) | Realized/unrealized P&L summary + top assets |
+| `get_allocation` | — | Allocation by asset type |
+| `get_performance_trend` | `days?` (positive int, default `30`) | Asset-value trend for the latest N days |
+
+All tools return raw JSON (numeric values + currency codes, not preformatted
+strings). Invalid arguments and not-found lookups return a structured tool
+error; the server never panics.
+
+## Auditing
+
+Every tool call (success or error) writes one row to the `agent_audit_log`
+table: tool name, arguments, status, error, a lightweight result summary, and
+duration. Logging is **best-effort** in Phase 1 — if the audit insert fails the
+server logs to stderr but still returns the result (a logging hiccup must not
+block reads). Fail-closed behavior is deferred to Phase 2.
+
+## Running
+
+Requires `.env.local` in `backend/` (same DB config as the API). Build/run:
+
+```bash
+make mcp-build   # -> backend/bin/mcp
+# or
+make mcp-run
+```
+
+## Configuring an MCP client
+
+Register the built binary as a stdio MCP server. Example client config:
+
+```json
+{
+  "mcpServers": {
+    "asset-manager": {
+      "command": "/absolute/path/to/asset-manager/backend/bin/mcp"
+    }
+  }
+}
+```
+
+The working directory must contain `.env.local` (or run the binary from
+`backend/`) so the database connection resolves.

--- a/backend/cmd/mcp/main.go
+++ b/backend/cmd/mcp/main.go
@@ -1,0 +1,80 @@
+// Command mcp runs the in-process MCP server (Phase 1, read-only) over stdio.
+// It reuses the same DB + service layer as cmd/api (no Redis cache path) and
+// records every tool call to agent_audit_log.
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/joho/godotenv"
+
+	"github.com/chienchuanw/asset-manager/internal/audit"
+	"github.com/chienchuanw/asset-manager/internal/client"
+	"github.com/chienchuanw/asset-manager/internal/db"
+	"github.com/chienchuanw/asset-manager/internal/mcpserver"
+	"github.com/chienchuanw/asset-manager/internal/repository"
+	"github.com/chienchuanw/asset-manager/internal/service"
+)
+
+func main() {
+	if err := godotenv.Load(".env.local"); err != nil {
+		log.Printf("Warning: .env.local not found: %v", err)
+	}
+
+	database, err := db.InitDB()
+	if err != nil {
+		log.Fatalf("Failed to initialize database: %v", err)
+	}
+	defer database.Close()
+
+	// Repositories
+	transactionRepo := repository.NewTransactionRepository(database)
+	exchangeRateRepo := repository.NewExchangeRateRepository(database)
+	realizedProfitRepo := repository.NewRealizedProfitRepository(database)
+	dbx := sqlx.NewDb(database, "postgres")
+	performanceSnapshotRepo := repository.NewPerformanceSnapshotRepository(dbx)
+
+	// Price service (real API if keys present, else mock) — no Redis cache.
+	var priceService service.PriceService
+	finmind := os.Getenv("FINMIND_API_KEY")
+	coingecko := os.Getenv("COINGECKO_API_KEY")
+	alpha := os.Getenv("ALPHA_VANTAGE_API_KEY")
+	if finmind != "" && coingecko != "" && alpha != "" {
+		priceService = service.NewRealPriceService(finmind, coingecko, alpha)
+	} else {
+		priceService = service.NewMockPriceService()
+		log.Println("Warning: price API keys not set, using mock price service")
+	}
+
+	exchangeRateClient := client.NewExchangeRateAPIClient()
+	exchangeRateService := service.NewExchangeRateService(exchangeRateRepo, exchangeRateClient, nil)
+	fifoCalculator := service.NewFIFOCalculator(exchangeRateService)
+	transactionService := service.NewTransactionService(transactionRepo, realizedProfitRepo, fifoCalculator, exchangeRateService)
+	holdingService := service.NewHoldingService(transactionRepo, fifoCalculator, priceService, exchangeRateService)
+	analyticsService := service.NewAnalyticsService(realizedProfitRepo)
+	unrealizedAnalyticsService := service.NewUnrealizedAnalyticsService(holdingService)
+	allocationService := service.NewAllocationService(holdingService)
+	performanceTrendService := service.NewPerformanceTrendService(performanceSnapshotRepo, unrealizedAnalyticsService, analyticsService)
+
+	logger := audit.NewLogger(audit.NewPostgresAuditRepository(database))
+
+	holdingsAdapter := mcpserver.NewHoldingsAdapter(holdingService)
+	txAdapter := mcpserver.NewTransactionsAdapter(transactionService)
+	tools := []mcpserver.Tool{
+		mcpserver.NewGetHoldingsTool(holdingsAdapter),
+		mcpserver.NewGetHoldingTool(holdingsAdapter),
+		mcpserver.NewListTransactionsTool(txAdapter),
+		mcpserver.NewGetTransactionTool(txAdapter),
+		mcpserver.NewGetAnalyticsTool(mcpserver.NewAnalyticsAdapter(analyticsService)),
+		mcpserver.NewGetAllocationTool(mcpserver.NewAllocationAdapter(allocationService)),
+		mcpserver.NewGetPerformanceTrendTool(mcpserver.NewTrendAdapter(performanceTrendService)),
+	}
+
+	dispatcher := mcpserver.NewDispatcher(tools, mcpserver.NewLoggerSink(logger))
+	if err := mcpserver.Serve(context.Background(), dispatcher, tools); err != nil {
+		log.Fatalf("mcp server: %v", err)
+	}
+}

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -8,12 +8,13 @@ require (
 	github.com/cucumber/godog v0.15.1
 	github.com/gin-contrib/cors v1.7.7
 	github.com/gin-gonic/gin v1.12.0
-	github.com/golang-jwt/jwt/v5 v5.3.0
+	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/generative-ai-go v0.20.1
 	github.com/google/uuid v1.6.0
 	github.com/jmoiron/sqlx v1.4.0
 	github.com/joho/godotenv v1.5.1
 	github.com/lib/pq v1.12.3
+	github.com/modelcontextprotocol/go-sdk v1.6.0
 	github.com/redis/go-redis/v9 v9.19.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/testify v1.11.1
@@ -56,6 +57,7 @@ require (
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/goccy/go-yaml v1.19.2 // indirect
 	github.com/gofrs/uuid v4.3.1+incompatible // indirect
+	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.15 // indirect
 	github.com/googleapis/gax-go/v2 v2.22.0 // indirect
@@ -75,10 +77,13 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
 	github.com/quic-go/quic-go v0.59.0 // indirect
+	github.com/segmentio/asm v1.1.3 // indirect
+	github.com/segmentio/encoding v0.5.4 // indirect
 	github.com/spf13/pflag v1.0.7 // indirect
 	github.com/stretchr/objx v0.5.3 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.3.1 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.mongodb.org/mongo-driver/v2 v2.5.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.67.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -100,8 +100,8 @@ github.com/goccy/go-yaml v1.19.2/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7Lk
 github.com/gofrs/uuid v4.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gofrs/uuid v4.3.1+incompatible h1:0/KbAdpx3UXAx1kEOWHJeOkpbgRFGHVgv+CFIY7dBJI=
 github.com/gofrs/uuid v4.3.1+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
-github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9vvo=
-github.com/golang-jwt/jwt/v5 v5.3.0/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/generative-ai-go v0.20.1 h1:6dEIujpgN2V0PgLhr6c/M1ynRdc7ARtiIDPFzj45uNQ=
@@ -109,6 +109,8 @@ github.com/google/generative-ai-go v0.20.1/go.mod h1:TjOnZJmZKzarWbjUJgy+r3Ee7HG
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/jsonschema-go v0.4.3 h1:/DBOLZTfDow7pe2GmaJNhltueGTtDKICi8V8p+DQPd0=
+github.com/google/jsonschema-go v0.4.3/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/s2a-go v0.1.9 h1:LGD7gtMgezd8a/Xak7mEWL0PjoTQFvpRudN895yqKW0=
 github.com/google/s2a-go v0.1.9/go.mod h1:YA0Ei2ZQL3acow2O62kdp9UlnvMmU7kA6Eutn0dXayM=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -163,6 +165,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
 github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
+github.com/modelcontextprotocol/go-sdk v1.6.0 h1:PPLS3kn7WtOEnR+Af4X5H96SG0qSab8R/ZQT/HkhPkY=
+github.com/modelcontextprotocol/go-sdk v1.6.0/go.mod h1:kzm3kzFL1/+AziGOE0nUs3gvPoNxMCvkxokMkuFapXQ=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -187,6 +191,10 @@ github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzG
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/segmentio/asm v1.1.3 h1:WM03sfUOENvvKexOLp+pCqgb/WDjsi7EK8gIsICtzhc=
+github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
+github.com/segmentio/encoding v0.5.4 h1:OW1VRern8Nw6ITAtwSZ7Idrl3MXCFwXHPgqESYfvNt0=
+github.com/segmentio/encoding v0.5.4/go.mod h1:HS1ZKa3kSN32ZHVZ7ZLPLXWvOVIiZtyJnO1gPH1sKt0=
 github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.7 h1:vN6T9TfwStFPFM5XzjsvmzZkLuaLX+HS+0SeFLRgU6M=
@@ -217,6 +225,8 @@ github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go/codec v1.3.1 h1:waO7eEiFDwidsBN6agj1vJQ4AG7lh2yqXyOXqhgQuyY=
 github.com/ugorji/go/codec v1.3.1/go.mod h1:pRBVtBSKl77K30Bv8R2P+cLSGaTtex6fsA2Wjqmfxj4=
+github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zeebo/xxh3 v1.1.0 h1:s7DLGDK45Dyfg7++yxI0khrfwq9661w9EN78eP/UZVs=
 github.com/zeebo/xxh3 v1.1.0/go.mod h1:IisAie1LELR4xhVinxWS5+zf1lA4p0MW4T+w+W07F5s=

--- a/backend/internal/audit/audit.go
+++ b/backend/internal/audit/audit.go
@@ -1,0 +1,36 @@
+package audit
+
+import (
+	"encoding/json"
+	"log"
+)
+
+type Entry struct {
+	Tool          string
+	Arguments     json.RawMessage
+	Status        string // "success" | "error"
+	Error         string
+	ResultSummary json.RawMessage
+	DurationMS    int
+}
+
+type Repository interface {
+	Record(e Entry) error
+}
+
+// Logger is the best-effort façade used by the server. A storage failure is
+// logged to stderr and swallowed so a logging hiccup never blocks a read
+// (Phase 1 policy; fail-closed is deferred to Phase 2).
+type Logger struct {
+	repo Repository
+}
+
+func NewLogger(repo Repository) *Logger {
+	return &Logger{repo: repo}
+}
+
+func (l *Logger) Record(e Entry) {
+	if err := l.repo.Record(e); err != nil {
+		log.Printf("audit: failed to record %s: %v", e.Tool, err)
+	}
+}

--- a/backend/internal/audit/audit_repository.go
+++ b/backend/internal/audit/audit_repository.go
@@ -1,0 +1,32 @@
+package audit
+
+import "database/sql"
+
+type PostgresAuditRepository struct {
+	db *sql.DB
+}
+
+func NewPostgresAuditRepository(db *sql.DB) *PostgresAuditRepository {
+	return &PostgresAuditRepository{db: db}
+}
+
+func (r *PostgresAuditRepository) Record(e Entry) error {
+	args := e.Arguments
+	if len(args) == 0 {
+		args = []byte("{}")
+	}
+	var errText any
+	if e.Error != "" {
+		errText = e.Error
+	}
+	var summary any
+	if len(e.ResultSummary) > 0 {
+		summary = []byte(e.ResultSummary)
+	}
+	_, err := r.db.Exec(
+		`INSERT INTO agent_audit_log (tool, arguments, status, error, result_summary, duration_ms)
+		 VALUES ($1, $2, $3, $4, $5, $6)`,
+		e.Tool, []byte(args), e.Status, errText, summary, e.DurationMS,
+	)
+	return err
+}

--- a/backend/internal/audit/audit_repository_test.go
+++ b/backend/internal/audit/audit_repository_test.go
@@ -1,0 +1,79 @@
+package audit
+
+import (
+	"database/sql"
+	"encoding/json"
+	"os"
+	"testing"
+
+	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testDB(t *testing.T) *sql.DB {
+	t.Helper()
+	get := func(k, d string) string {
+		if v := os.Getenv(k); v != "" {
+			return v
+		}
+		return d
+	}
+	dsn := "host=" + get("TEST_DB_HOST", "localhost") +
+		" port=" + get("TEST_DB_PORT", "5432") +
+		" user=" + get("TEST_DB_USER", "postgres") +
+		" password=" + get("TEST_DB_PASSWORD", "postgres") +
+		" dbname=" + get("TEST_DB_NAME", "asset_manager_test") +
+		" sslmode=disable"
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	require.NoError(t, db.Ping())
+	return db
+}
+
+func TestPostgresAuditRepository_Record(t *testing.T) {
+	db := testDB(t)
+	defer db.Close()
+	_, err := db.Exec("DELETE FROM agent_audit_log")
+	require.NoError(t, err)
+
+	repo := NewPostgresAuditRepository(db)
+	err = repo.Record(Entry{
+		Tool:          "get_holdings",
+		Arguments:     json.RawMessage(`{"a":1}`),
+		Status:        "success",
+		ResultSummary: json.RawMessage(`{"rows":3}`),
+		DurationMS:    12,
+	})
+	assert.NoError(t, err)
+
+	var tool, status string
+	var dur int
+	row := db.QueryRow("SELECT tool, status, duration_ms FROM agent_audit_log LIMIT 1")
+	require.NoError(t, row.Scan(&tool, &status, &dur))
+	assert.Equal(t, "get_holdings", tool)
+	assert.Equal(t, "success", status)
+	assert.Equal(t, 12, dur)
+}
+
+func TestPostgresAuditRepository_RecordError(t *testing.T) {
+	db := testDB(t)
+	defer db.Close()
+	_, err := db.Exec("DELETE FROM agent_audit_log")
+	require.NoError(t, err)
+
+	repo := NewPostgresAuditRepository(db)
+	err = repo.Record(Entry{
+		Tool:       "get_holding",
+		Status:     "error",
+		Error:      "symbol not found",
+		DurationMS: 4,
+	})
+	assert.NoError(t, err)
+
+	var status, errText string
+	row := db.QueryRow("SELECT status, error FROM agent_audit_log LIMIT 1")
+	require.NoError(t, row.Scan(&status, &errText))
+	assert.Equal(t, "error", status)
+	assert.Equal(t, "symbol not found", errText)
+}

--- a/backend/internal/mcpserver/adapters.go
+++ b/backend/internal/mcpserver/adapters.go
@@ -1,0 +1,118 @@
+// Package mcpserver exposes read-only portfolio data to AI agents over MCP.
+// Adapters are thin wrappers over the existing service layer (same pattern as
+// internal/discord) — they select the read methods the tools need and return
+// the domain models, which already carry JSON tags with raw numeric values.
+package mcpserver
+
+import (
+	"github.com/chienchuanw/asset-manager/internal/models"
+	"github.com/chienchuanw/asset-manager/internal/repository"
+	"github.com/chienchuanw/asset-manager/internal/service"
+	"github.com/google/uuid"
+)
+
+// --- holdings ---
+
+type holdingReader interface {
+	GetAllHoldings(models.HoldingFilters) (*service.HoldingServiceResult, error)
+	GetHoldingBySymbol(string) (*models.Holding, error)
+}
+
+type HoldingsAdapter struct{ svc holdingReader }
+
+func NewHoldingsAdapter(svc holdingReader) *HoldingsAdapter { return &HoldingsAdapter{svc: svc} }
+
+func (a *HoldingsAdapter) List() ([]*models.Holding, error) {
+	res, err := a.svc.GetAllHoldings(models.HoldingFilters{})
+	if err != nil {
+		return nil, err
+	}
+	return res.Holdings, nil
+}
+
+func (a *HoldingsAdapter) Get(symbol string) (*models.Holding, error) {
+	return a.svc.GetHoldingBySymbol(symbol)
+}
+
+// --- transactions ---
+
+type transactionReader interface {
+	ListTransactions(repository.TransactionFilters) ([]*models.Transaction, error)
+	GetTransaction(uuid.UUID) (*models.Transaction, error)
+}
+
+type TransactionsAdapter struct{ svc transactionReader }
+
+func NewTransactionsAdapter(svc transactionReader) *TransactionsAdapter {
+	return &TransactionsAdapter{svc: svc}
+}
+
+func (a *TransactionsAdapter) List(f repository.TransactionFilters) ([]*models.Transaction, error) {
+	return a.svc.ListTransactions(f)
+}
+
+func (a *TransactionsAdapter) Get(id string) (*models.Transaction, error) {
+	uid, err := uuid.Parse(id)
+	if err != nil {
+		return nil, err
+	}
+	return a.svc.GetTransaction(uid)
+}
+
+// --- analytics ---
+
+type analyticsReader interface {
+	GetSummary(models.TimeRange) (*models.AnalyticsSummary, error)
+	GetTopAssets(models.TimeRange, int) ([]*models.TopAsset, error)
+}
+
+type AnalyticsAdapter struct{ svc analyticsReader }
+
+func NewAnalyticsAdapter(svc analyticsReader) *AnalyticsAdapter { return &AnalyticsAdapter{svc: svc} }
+
+type AnalyticsResult struct {
+	Summary   *models.AnalyticsSummary `json:"summary"`
+	TopAssets []*models.TopAsset       `json:"top_assets"`
+}
+
+func (a *AnalyticsAdapter) Get(tr models.TimeRange) (*AnalyticsResult, error) {
+	sum, err := a.svc.GetSummary(tr)
+	if err != nil {
+		return nil, err
+	}
+	top, err := a.svc.GetTopAssets(tr, 5)
+	if err != nil {
+		return nil, err
+	}
+	return &AnalyticsResult{Summary: sum, TopAssets: top}, nil
+}
+
+// --- allocation ---
+
+type allocationReader interface {
+	GetAllocationByType() ([]models.AllocationByType, error)
+}
+
+type AllocationAdapter struct{ svc allocationReader }
+
+func NewAllocationAdapter(svc allocationReader) *AllocationAdapter {
+	return &AllocationAdapter{svc: svc}
+}
+
+func (a *AllocationAdapter) ByType() ([]models.AllocationByType, error) {
+	return a.svc.GetAllocationByType()
+}
+
+// --- performance trend ---
+
+type trendReader interface {
+	GetLatestTrend(int) ([]models.PerformanceTrendPoint, error)
+}
+
+type TrendAdapter struct{ svc trendReader }
+
+func NewTrendAdapter(svc trendReader) *TrendAdapter { return &TrendAdapter{svc: svc} }
+
+func (a *TrendAdapter) Latest(days int) ([]models.PerformanceTrendPoint, error) {
+	return a.svc.GetLatestTrend(days)
+}

--- a/backend/internal/mcpserver/adapters_test.go
+++ b/backend/internal/mcpserver/adapters_test.go
@@ -1,0 +1,77 @@
+package mcpserver
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/chienchuanw/asset-manager/internal/models"
+	"github.com/chienchuanw/asset-manager/internal/repository"
+	"github.com/chienchuanw/asset-manager/internal/service"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeHoldingSvc struct {
+	all *service.HoldingServiceResult
+	one *models.Holding
+	err error
+}
+
+func (f fakeHoldingSvc) GetAllHoldings(models.HoldingFilters) (*service.HoldingServiceResult, error) {
+	return f.all, f.err
+}
+func (f fakeHoldingSvc) GetHoldingBySymbol(string) (*models.Holding, error) { return f.one, f.err }
+
+func TestHoldingsAdapter_List(t *testing.T) {
+	a := NewHoldingsAdapter(fakeHoldingSvc{all: &service.HoldingServiceResult{
+		Holdings: []*models.Holding{{Symbol: "2330", Name: "TSMC", Quantity: 10}},
+	}})
+	out, err := a.List()
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	assert.Equal(t, "2330", out[0].Symbol)
+	assert.Equal(t, 10.0, out[0].Quantity)
+}
+
+func TestHoldingsAdapter_ListError(t *testing.T) {
+	a := NewHoldingsAdapter(fakeHoldingSvc{err: errors.New("boom")})
+	_, err := a.List()
+	assert.ErrorContains(t, err, "boom")
+}
+
+type fakeTxSvc struct {
+	list []*models.Transaction
+	one  *models.Transaction
+	err  error
+}
+
+func (f fakeTxSvc) ListTransactions(repository.TransactionFilters) ([]*models.Transaction, error) {
+	return f.list, f.err
+}
+func (f fakeTxSvc) GetTransaction(uuid.UUID) (*models.Transaction, error) { return f.one, f.err }
+
+func TestTransactionsAdapter_List(t *testing.T) {
+	a := NewTransactionsAdapter(fakeTxSvc{list: []*models.Transaction{{Symbol: "AAPL"}}})
+	out, err := a.List(repository.TransactionFilters{})
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	assert.Equal(t, "AAPL", out[0].Symbol)
+}
+
+func TestTransactionsAdapter_GetInvalidUUID(t *testing.T) {
+	a := NewTransactionsAdapter(fakeTxSvc{})
+	_, err := a.Get("not-a-uuid")
+	assert.Error(t, err)
+}
+
+type fakeAllocSvc struct{ rows []models.AllocationByType }
+
+func (f fakeAllocSvc) GetAllocationByType() ([]models.AllocationByType, error) { return f.rows, nil }
+
+func TestAllocationAdapter_ByType(t *testing.T) {
+	a := NewAllocationAdapter(fakeAllocSvc{rows: []models.AllocationByType{{}}})
+	out, err := a.ByType()
+	require.NoError(t, err)
+	assert.Len(t, out, 1)
+}

--- a/backend/internal/mcpserver/server.go
+++ b/backend/internal/mcpserver/server.go
@@ -1,0 +1,122 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/chienchuanw/asset-manager/internal/audit"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// auditSink is the narrow logging contract the dispatcher needs (kept
+// SDK-independent so dispatch logic is unit-testable without a DB).
+type auditSink interface {
+	Record(tool, status string, args, summary json.RawMessage, durationMS int, errMsg string)
+}
+
+// loggerSink adapts *audit.Logger to auditSink.
+type loggerSink struct{ l *audit.Logger }
+
+func NewLoggerSink(l *audit.Logger) auditSink { return loggerSink{l: l} }
+
+func (s loggerSink) Record(tool, status string, args, summary json.RawMessage, durationMS int, errMsg string) {
+	s.l.Record(audit.Entry{
+		Tool:          tool,
+		Arguments:     args,
+		Status:        status,
+		Error:         errMsg,
+		ResultSummary: summary,
+		DurationMS:    durationMS,
+	})
+}
+
+// Dispatcher routes a tool name to its Tool and audits every call.
+type Dispatcher struct {
+	tools map[string]Tool
+	audit auditSink
+}
+
+func NewDispatcher(tools []Tool, a auditSink) *Dispatcher {
+	m := make(map[string]Tool, len(tools))
+	for _, t := range tools {
+		m[t.Name()] = t
+	}
+	return &Dispatcher{tools: m, audit: a}
+}
+
+func (d *Dispatcher) Dispatch(name string, args json.RawMessage) (json.RawMessage, error) {
+	start := time.Now()
+	tool, ok := d.tools[name]
+	if !ok {
+		d.audit.Record(name, "error", args, nil, ms(start), "unknown tool")
+		return nil, fmt.Errorf("unknown tool: %s", name)
+	}
+	payload, summary, err := tool.Run(args)
+	if err != nil {
+		d.audit.Record(name, "error", args, nil, ms(start), err.Error())
+		return nil, err
+	}
+	d.audit.Record(name, "success", args, summary, ms(start), "")
+	return payload, nil
+}
+
+func ms(start time.Time) int { return int(time.Since(start).Milliseconds()) }
+
+// BuildServer registers every tool with the MCP SDK server. The SDK is
+// isolated here; tool/dispatch logic above is testable without it, and this
+// function is reusable by both stdio serving and in-memory transport tests.
+func BuildServer(d *Dispatcher, tools []Tool) *mcp.Server {
+	srv := mcp.NewServer(&mcp.Implementation{
+		Name:    "asset-manager",
+		Version: "0.1.0",
+	}, nil)
+
+	for _, t := range tools {
+		name := t.Name()
+		handler := func(_ context.Context, _ *mcp.CallToolRequest, in map[string]any) (*mcp.CallToolResult, any, error) {
+			raw, mErr := json.Marshal(in)
+			if mErr != nil {
+				raw = []byte("{}")
+			}
+			payload, err := d.Dispatch(name, raw)
+			if err != nil {
+				return &mcp.CallToolResult{
+					IsError: true,
+					Content: []mcp.Content{&mcp.TextContent{Text: err.Error()}},
+				}, nil, nil
+			}
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{Text: string(payload)}},
+			}, nil, nil
+		}
+		mcp.AddTool(srv, &mcp.Tool{Name: name, Description: descriptionFor(name)}, handler)
+	}
+	return srv
+}
+
+// Serve runs the MCP server over stdio.
+func Serve(ctx context.Context, d *Dispatcher, tools []Tool) error {
+	return BuildServer(d, tools).Run(ctx, &mcp.StdioTransport{})
+}
+
+func descriptionFor(name string) string {
+	switch name {
+	case "get_holdings":
+		return "List all current holdings with quantity, average cost, market value and unrealized P&L."
+	case "get_holding":
+		return "Get a single holding by symbol."
+	case "list_transactions":
+		return "List transactions, optionally filtered by from/to (YYYY-MM-DD), type, symbol, limit."
+	case "get_transaction":
+		return "Get a single transaction by id (UUID)."
+	case "get_analytics":
+		return "Get realized/unrealized P&L summary and top assets for a range (week|month|quarter|year|all)."
+	case "get_allocation":
+		return "Get current allocation broken down by asset type."
+	case "get_performance_trend":
+		return "Get asset-value performance trend for the latest N days (default 30)."
+	}
+	return name
+}

--- a/backend/internal/mcpserver/server_integration_test.go
+++ b/backend/internal/mcpserver/server_integration_test.go
@@ -1,0 +1,88 @@
+package mcpserver
+
+import (
+	"database/sql"
+	"encoding/json"
+	"os"
+	"testing"
+
+	_ "github.com/lib/pq"
+	"github.com/chienchuanw/asset-manager/internal/audit"
+	"github.com/chienchuanw/asset-manager/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type auditSpy struct {
+	entries []spyEntry
+}
+type spyEntry struct {
+	tool, status string
+}
+
+func (s *auditSpy) Record(tool, status string, _, _ json.RawMessage, _ int, _ string) {
+	s.entries = append(s.entries, spyEntry{tool, status})
+}
+
+func TestDispatch_AuditsSuccessAndError(t *testing.T) {
+	spy := &auditSpy{}
+	d := NewDispatcher(
+		[]Tool{NewGetHoldingsTool(fakeHoldingsPort{list: []*models.Holding{{Symbol: "X"}}})},
+		spy,
+	)
+
+	payload, err := d.Dispatch("get_holdings", json.RawMessage(`{}`))
+	require.NoError(t, err)
+	assert.Contains(t, string(payload), "X")
+
+	_, err = d.Dispatch("does_not_exist", json.RawMessage(`{}`))
+	assert.Error(t, err)
+
+	require.Len(t, spy.entries, 2)
+	assert.Equal(t, spyEntry{"get_holdings", "success"}, spy.entries[0])
+	assert.Equal(t, spyEntry{"does_not_exist", "error"}, spy.entries[1])
+}
+
+func testDB(t *testing.T) *sql.DB {
+	t.Helper()
+	get := func(k, d string) string {
+		if v := os.Getenv(k); v != "" {
+			return v
+		}
+		return d
+	}
+	dsn := "host=" + get("TEST_DB_HOST", "localhost") +
+		" port=" + get("TEST_DB_PORT", "5432") +
+		" user=" + get("TEST_DB_USER", "postgres") +
+		" password=" + get("TEST_DB_PASSWORD", "postgres") +
+		" dbname=" + get("TEST_DB_NAME", "asset_manager_test") +
+		" sslmode=disable"
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	require.NoError(t, db.Ping())
+	return db
+}
+
+// End-to-end: real audit repository, real dispatcher, fake adapter data.
+func TestDispatch_WritesAuditRowToDB(t *testing.T) {
+	db := testDB(t)
+	defer db.Close()
+	_, err := db.Exec("DELETE FROM agent_audit_log")
+	require.NoError(t, err)
+
+	sink := NewLoggerSink(audit.NewLogger(audit.NewPostgresAuditRepository(db)))
+	d := NewDispatcher(
+		[]Tool{NewGetHoldingsTool(fakeHoldingsPort{list: []*models.Holding{{Symbol: "2330"}}})},
+		sink,
+	)
+
+	payload, err := d.Dispatch("get_holdings", json.RawMessage(`{}`))
+	require.NoError(t, err)
+	assert.Contains(t, string(payload), "2330")
+
+	var tool, status string
+	row := db.QueryRow("SELECT tool, status FROM agent_audit_log LIMIT 1")
+	require.NoError(t, row.Scan(&tool, &status))
+	assert.Equal(t, "get_holdings", tool)
+	assert.Equal(t, "success", status)
+}

--- a/backend/internal/mcpserver/server_sdk_test.go
+++ b/backend/internal/mcpserver/server_sdk_test.go
@@ -1,0 +1,78 @@
+package mcpserver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/chienchuanw/asset-manager/internal/audit"
+	"github.com/chienchuanw/asset-manager/internal/models"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// End-to-end through the real SDK over in-memory transports: a client lists
+// the 7 tools and calls get_holdings; a real audit row is written.
+func TestSDKServer_ListAndCallToolsWithAudit(t *testing.T) {
+	db := testDB(t)
+	defer db.Close()
+	_, err := db.Exec("DELETE FROM agent_audit_log")
+	require.NoError(t, err)
+
+	holdings := fakeHoldingsPort{list: []*models.Holding{{Symbol: "2330", Name: "TSMC"}}}
+	tools := []Tool{
+		NewGetHoldingsTool(holdings),
+		NewGetHoldingTool(holdings),
+		NewListTransactionsTool(fakeTxPort{}),
+		NewGetTransactionTool(fakeTxPort{}),
+		NewGetAnalyticsTool(fakeAnalyticsPort{res: &AnalyticsResult{}}),
+		NewGetAllocationTool(fakeAllocPortE2E{}),
+		NewGetPerformanceTrendTool(fakeTrendPort{}),
+	}
+	sink := NewLoggerSink(audit.NewLogger(audit.NewPostgresAuditRepository(db)))
+	srv := BuildServer(NewDispatcher(tools, sink), tools)
+
+	ctx := context.Background()
+	clientT, serverT := mcp.NewInMemoryTransports()
+	ss, err := srv.Connect(ctx, serverT, nil)
+	require.NoError(t, err)
+	defer ss.Close()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test", Version: "1"}, nil)
+	cs, err := client.Connect(ctx, clientT, nil)
+	require.NoError(t, err)
+	defer cs.Close()
+
+	listed, err := cs.ListTools(ctx, nil)
+	require.NoError(t, err)
+	names := map[string]bool{}
+	for _, tl := range listed.Tools {
+		names[tl.Name] = true
+	}
+	for _, want := range []string{
+		"get_holdings", "get_holding", "list_transactions", "get_transaction",
+		"get_analytics", "get_allocation", "get_performance_trend",
+	} {
+		assert.True(t, names[want], "tool %s should be listed", want)
+	}
+	assert.Len(t, listed.Tools, 7)
+
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{Name: "get_holdings"})
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+	require.NotEmpty(t, res.Content)
+	tc, ok := res.Content[0].(*mcp.TextContent)
+	require.True(t, ok)
+	assert.Contains(t, tc.Text, "2330")
+
+	var tool, status string
+	row := db.QueryRow("SELECT tool, status FROM agent_audit_log WHERE tool='get_holdings' LIMIT 1")
+	require.NoError(t, row.Scan(&tool, &status))
+	assert.Equal(t, "success", status)
+}
+
+type fakeAllocPortE2E struct{}
+
+func (fakeAllocPortE2E) ByType() ([]models.AllocationByType, error) {
+	return []models.AllocationByType{}, nil
+}

--- a/backend/internal/mcpserver/tools_read.go
+++ b/backend/internal/mcpserver/tools_read.go
@@ -1,0 +1,269 @@
+package mcpserver
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/chienchuanw/asset-manager/internal/models"
+	"github.com/chienchuanw/asset-manager/internal/repository"
+)
+
+// Tool is the SDK-independent contract: parse raw args, return the JSON
+// payload and a lightweight summary for the audit log.
+type Tool interface {
+	Name() string
+	Run(args json.RawMessage) (payload json.RawMessage, summary json.RawMessage, err error)
+}
+
+func okSummary() json.RawMessage          { return json.RawMessage(`{"ok":true}`) }
+func rowsSummary(n int) json.RawMessage   { b, _ := json.Marshal(map[string]int{"rows": n}); return b }
+func marshalPayload(v any) (json.RawMessage, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, fmt.Errorf("encode result: %w", err)
+	}
+	return b, nil
+}
+
+// --- get_holdings ---
+
+type holdingsPort interface {
+	List() ([]*models.Holding, error)
+	Get(symbol string) (*models.Holding, error)
+}
+
+type getHoldingsTool struct{ port holdingsPort }
+
+func NewGetHoldingsTool(p holdingsPort) Tool { return &getHoldingsTool{p} }
+func (t *getHoldingsTool) Name() string      { return "get_holdings" }
+func (t *getHoldingsTool) Run(json.RawMessage) (json.RawMessage, json.RawMessage, error) {
+	rows, err := t.port.List()
+	if err != nil {
+		return nil, nil, err
+	}
+	p, err := marshalPayload(rows)
+	if err != nil {
+		return nil, nil, err
+	}
+	return p, rowsSummary(len(rows)), nil
+}
+
+// --- get_holding ---
+
+type getHoldingArgs struct {
+	Symbol string `json:"symbol"`
+}
+type getHoldingTool struct{ port holdingsPort }
+
+func NewGetHoldingTool(p holdingsPort) Tool { return &getHoldingTool{p} }
+func (t *getHoldingTool) Name() string      { return "get_holding" }
+func (t *getHoldingTool) Run(raw json.RawMessage) (json.RawMessage, json.RawMessage, error) {
+	var a getHoldingArgs
+	if err := json.Unmarshal(raw, &a); err != nil {
+		return nil, nil, fmt.Errorf("invalid arguments: %w", err)
+	}
+	if a.Symbol == "" {
+		return nil, nil, fmt.Errorf("symbol is required")
+	}
+	h, err := t.port.Get(a.Symbol)
+	if err != nil {
+		return nil, nil, fmt.Errorf("holding %q not found: %w", a.Symbol, err)
+	}
+	p, err := marshalPayload(h)
+	if err != nil {
+		return nil, nil, err
+	}
+	return p, okSummary(), nil
+}
+
+// --- list_transactions ---
+
+type txPort interface {
+	List(repository.TransactionFilters) ([]*models.Transaction, error)
+	Get(id string) (*models.Transaction, error)
+}
+
+type listTxArgs struct {
+	From   string `json:"from"`
+	To     string `json:"to"`
+	Type   string `json:"type"`
+	Symbol string `json:"symbol"`
+	Limit  int    `json:"limit"`
+}
+type listTransactionsTool struct{ port txPort }
+
+func NewListTransactionsTool(p txPort) Tool { return &listTransactionsTool{p} }
+func (t *listTransactionsTool) Name() string { return "list_transactions" }
+func (t *listTransactionsTool) Run(raw json.RawMessage) (json.RawMessage, json.RawMessage, error) {
+	var a listTxArgs
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &a); err != nil {
+			return nil, nil, fmt.Errorf("invalid arguments: %w", err)
+		}
+	}
+	var f repository.TransactionFilters
+	if a.Symbol != "" {
+		f.Symbol = &a.Symbol
+	}
+	if a.Type != "" {
+		tt := models.TransactionType(a.Type)
+		f.TransactionType = &tt
+	}
+	if a.From != "" {
+		d, err := time.Parse("2006-01-02", a.From)
+		if err != nil {
+			return nil, nil, fmt.Errorf("invalid 'from' date (want YYYY-MM-DD): %w", err)
+		}
+		f.StartDate = &d
+	}
+	if a.To != "" {
+		d, err := time.Parse("2006-01-02", a.To)
+		if err != nil {
+			return nil, nil, fmt.Errorf("invalid 'to' date (want YYYY-MM-DD): %w", err)
+		}
+		f.EndDate = &d
+	}
+	if a.Limit > 0 {
+		f.Limit = a.Limit
+	}
+	rows, err := t.port.List(f)
+	if err != nil {
+		return nil, nil, err
+	}
+	p, err := marshalPayload(rows)
+	if err != nil {
+		return nil, nil, err
+	}
+	return p, rowsSummary(len(rows)), nil
+}
+
+// --- get_transaction ---
+
+type getTxArgs struct {
+	ID string `json:"id"`
+}
+type getTransactionTool struct{ port txPort }
+
+func NewGetTransactionTool(p txPort) Tool { return &getTransactionTool{p} }
+func (t *getTransactionTool) Name() string { return "get_transaction" }
+func (t *getTransactionTool) Run(raw json.RawMessage) (json.RawMessage, json.RawMessage, error) {
+	var a getTxArgs
+	if err := json.Unmarshal(raw, &a); err != nil {
+		return nil, nil, fmt.Errorf("invalid arguments: %w", err)
+	}
+	if a.ID == "" {
+		return nil, nil, fmt.Errorf("id is required")
+	}
+	tx, err := t.port.Get(a.ID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("transaction %q not found: %w", a.ID, err)
+	}
+	p, err := marshalPayload(tx)
+	if err != nil {
+		return nil, nil, err
+	}
+	return p, okSummary(), nil
+}
+
+// --- get_analytics ---
+
+type analyticsPort interface {
+	Get(models.TimeRange) (*AnalyticsResult, error)
+}
+type rangeArgs struct {
+	Range string `json:"range"`
+}
+type getAnalyticsTool struct{ port analyticsPort }
+
+func NewGetAnalyticsTool(p analyticsPort) Tool { return &getAnalyticsTool{p} }
+func (t *getAnalyticsTool) Name() string       { return "get_analytics" }
+
+func parseRange(v string) (models.TimeRange, error) {
+	if v == "" {
+		return models.TimeRangeAll, nil
+	}
+	tr := models.TimeRange(v)
+	switch tr {
+	case models.TimeRangeWeek, models.TimeRangeMonth, models.TimeRangeQuarter,
+		models.TimeRangeYear, models.TimeRangeAll:
+		return tr, nil
+	}
+	return "", fmt.Errorf("invalid range %q (want week|month|quarter|year|all)", v)
+}
+
+func (t *getAnalyticsTool) Run(raw json.RawMessage) (json.RawMessage, json.RawMessage, error) {
+	var a rangeArgs
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &a); err != nil {
+			return nil, nil, fmt.Errorf("invalid arguments: %w", err)
+		}
+	}
+	tr, err := parseRange(a.Range)
+	if err != nil {
+		return nil, nil, err
+	}
+	res, err := t.port.Get(tr)
+	if err != nil {
+		return nil, nil, err
+	}
+	p, err := marshalPayload(res)
+	if err != nil {
+		return nil, nil, err
+	}
+	return p, okSummary(), nil
+}
+
+// --- get_allocation ---
+
+type allocPort interface {
+	ByType() ([]models.AllocationByType, error)
+}
+type getAllocationTool struct{ port allocPort }
+
+func NewGetAllocationTool(p allocPort) Tool { return &getAllocationTool{p} }
+func (t *getAllocationTool) Name() string    { return "get_allocation" }
+func (t *getAllocationTool) Run(json.RawMessage) (json.RawMessage, json.RawMessage, error) {
+	rows, err := t.port.ByType()
+	if err != nil {
+		return nil, nil, err
+	}
+	p, err := marshalPayload(rows)
+	if err != nil {
+		return nil, nil, err
+	}
+	return p, rowsSummary(len(rows)), nil
+}
+
+// --- get_performance_trend ---
+
+type trendPort interface {
+	Latest(days int) ([]models.PerformanceTrendPoint, error)
+}
+type trendArgs struct {
+	Days int `json:"days"`
+}
+type getPerformanceTrendTool struct{ port trendPort }
+
+func NewGetPerformanceTrendTool(p trendPort) Tool { return &getPerformanceTrendTool{p} }
+func (t *getPerformanceTrendTool) Name() string    { return "get_performance_trend" }
+func (t *getPerformanceTrendTool) Run(raw json.RawMessage) (json.RawMessage, json.RawMessage, error) {
+	a := trendArgs{Days: 30}
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &a); err != nil {
+			return nil, nil, fmt.Errorf("invalid arguments: %w", err)
+		}
+	}
+	if a.Days <= 0 {
+		return nil, nil, fmt.Errorf("days must be a positive integer")
+	}
+	rows, err := t.port.Latest(a.Days)
+	if err != nil {
+		return nil, nil, err
+	}
+	p, err := marshalPayload(rows)
+	if err != nil {
+		return nil, nil, err
+	}
+	return p, rowsSummary(len(rows)), nil
+}

--- a/backend/internal/mcpserver/tools_read_test.go
+++ b/backend/internal/mcpserver/tools_read_test.go
@@ -1,0 +1,106 @@
+package mcpserver
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/chienchuanw/asset-manager/internal/models"
+	"github.com/chienchuanw/asset-manager/internal/repository"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeHoldingsPort struct {
+	list []*models.Holding
+	one  *models.Holding
+	err  error
+}
+
+func (f fakeHoldingsPort) List() ([]*models.Holding, error)         { return f.list, f.err }
+func (f fakeHoldingsPort) Get(string) (*models.Holding, error)      { return f.one, f.err }
+
+func TestGetHoldingsTool_Success(t *testing.T) {
+	tool := NewGetHoldingsTool(fakeHoldingsPort{list: []*models.Holding{{Symbol: "2330"}}})
+	payload, summary, err := tool.Run(json.RawMessage(`{}`))
+	require.NoError(t, err)
+	assert.Contains(t, string(payload), "2330")
+	assert.JSONEq(t, `{"rows":1}`, string(summary))
+}
+
+func TestGetHoldingTool_MissingSymbol(t *testing.T) {
+	tool := NewGetHoldingTool(fakeHoldingsPort{})
+	_, _, err := tool.Run(json.RawMessage(`{}`))
+	assert.ErrorContains(t, err, "symbol")
+}
+
+func TestGetHoldingTool_NotFound(t *testing.T) {
+	tool := NewGetHoldingTool(fakeHoldingsPort{err: errors.New("nope")})
+	_, _, err := tool.Run(json.RawMessage(`{"symbol":"ZZZ"}`))
+	assert.ErrorContains(t, err, "not found")
+}
+
+type fakeTxPort struct {
+	list []*models.Transaction
+	one  *models.Transaction
+	err  error
+}
+
+func (f fakeTxPort) List(repository.TransactionFilters) ([]*models.Transaction, error) {
+	return f.list, f.err
+}
+func (f fakeTxPort) Get(string) (*models.Transaction, error) { return f.one, f.err }
+
+func TestListTransactionsTool_BadDate(t *testing.T) {
+	tool := NewListTransactionsTool(fakeTxPort{})
+	_, _, err := tool.Run(json.RawMessage(`{"from":"18-05-2026"}`))
+	assert.ErrorContains(t, err, "from")
+}
+
+func TestListTransactionsTool_Success(t *testing.T) {
+	tool := NewListTransactionsTool(fakeTxPort{list: []*models.Transaction{{Symbol: "AAPL"}}})
+	payload, summary, err := tool.Run(json.RawMessage(`{"symbol":"AAPL"}`))
+	require.NoError(t, err)
+	assert.Contains(t, string(payload), "AAPL")
+	assert.JSONEq(t, `{"rows":1}`, string(summary))
+}
+
+func TestGetTransactionTool_MissingID(t *testing.T) {
+	tool := NewGetTransactionTool(fakeTxPort{})
+	_, _, err := tool.Run(json.RawMessage(`{}`))
+	assert.ErrorContains(t, err, "id")
+}
+
+type fakeAnalyticsPort struct{ res *AnalyticsResult }
+
+func (f fakeAnalyticsPort) Get(models.TimeRange) (*AnalyticsResult, error) { return f.res, nil }
+
+func TestGetAnalyticsTool_InvalidRange(t *testing.T) {
+	tool := NewGetAnalyticsTool(fakeAnalyticsPort{})
+	_, _, err := tool.Run(json.RawMessage(`{"range":"decade"}`))
+	assert.ErrorContains(t, err, "invalid range")
+}
+
+func TestGetAnalyticsTool_DefaultRange(t *testing.T) {
+	tool := NewGetAnalyticsTool(fakeAnalyticsPort{res: &AnalyticsResult{}})
+	_, summary, err := tool.Run(json.RawMessage(`{}`))
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"ok":true}`, string(summary))
+}
+
+type fakeTrendPort struct{ rows []models.PerformanceTrendPoint }
+
+func (f fakeTrendPort) Latest(int) ([]models.PerformanceTrendPoint, error) { return f.rows, nil }
+
+func TestGetPerformanceTrendTool_RejectsNonPositiveDays(t *testing.T) {
+	tool := NewGetPerformanceTrendTool(fakeTrendPort{})
+	_, _, err := tool.Run(json.RawMessage(`{"days":0}`))
+	assert.ErrorContains(t, err, "positive")
+}
+
+func TestGetPerformanceTrendTool_DefaultDays(t *testing.T) {
+	tool := NewGetPerformanceTrendTool(fakeTrendPort{rows: []models.PerformanceTrendPoint{{}}})
+	_, summary, err := tool.Run(json.RawMessage(`{}`))
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"rows":1}`, string(summary))
+}

--- a/backend/migrations/000032_agent_audit_log.down.sql
+++ b/backend/migrations/000032_agent_audit_log.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS agent_audit_log;

--- a/backend/migrations/000032_agent_audit_log.up.sql
+++ b/backend/migrations/000032_agent_audit_log.up.sql
@@ -1,0 +1,12 @@
+CREATE TABLE agent_audit_log (
+    id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tool           TEXT NOT NULL,
+    arguments      JSONB NOT NULL DEFAULT '{}'::jsonb,
+    status         TEXT NOT NULL CHECK (status IN ('success', 'error')),
+    error          TEXT,
+    result_summary JSONB,
+    duration_ms    INTEGER NOT NULL,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_agent_audit_log_created_at ON agent_audit_log (created_at DESC);
+CREATE INDEX idx_agent_audit_log_tool ON agent_audit_log (tool);


### PR DESCRIPTION
## 摘要

Closes #123

新增 in-process Go MCP server,讓 AI agent 透過 stdio 唯讀存取投資組合資料,並將每次工具呼叫寫入稽核表。MCP agent 存取計畫 Phase 1。純後端、唯讀、不改動既有 service。

## 變更內容

- **migration `000032_agent_audit_log`**:新增稽核表(id, tool, arguments jsonb, status, error, result_summary jsonb, duration_ms, created_at + 2 索引)
- **`internal/audit`**:`Entry`/`Repository`/`Logger`(best-effort:寫入失敗記 stderr 不阻斷)+ Postgres repository
- **`internal/mcpserver`**:
  - `adapters.go` — 薄 adapter 包覆既有 service(沿用 Discord adapter 模式),回傳帶 JSON tag 的 domain model
  - `tools_read.go` — 7 個 SDK-independent 工具:`get_holdings`、`get_holding`、`list_transactions`、`get_transaction`、`get_analytics`、`get_allocation`、`get_performance_trend`(參數驗證 + 結構化錯誤)
  - `server.go` — `Dispatcher`(每次呼叫稽核)+ `BuildServer`/`Serve`(官方 SDK 隔離於此,stdio)
- **`cmd/mcp/main.go`** — 載入 `.env.local`、開 DB、複用 `cmd/api` 服務建構(無 Redis 路徑)、註冊工具、stdio 服務
- **`Makefile`** — `mcp-build` / `mcp-run`;**`cmd/mcp/README.md`** — 工具表 + MCP client 設定說明
- 依賴:新增 `github.com/modelcontextprotocol/go-sdk v1.6.0`(`go mod tidy`)

## 測試

- `internal/audit`、`internal/mcpserver` 全綠:adapter 單元(mock service)、tool 單元(參數驗證/錯誤路徑)、dispatcher 稽核(success/error/unknown)、DB 稽核列、**透過真實 SDK in-memory transport 的端對端**(client 列出 7 工具、呼叫 `get_holdings`、驗證稽核列)
- `make test-unit`:328 測試全綠(`internal/service/*` 未變更,無回歸)
- `go build ./...` 成功;`make mcp-build` 成功

## 設計備註 / 與規格的差異

- Adapter 直接回傳 domain model(已具良好 JSON tag)而非另立 DTO — YAGNI 簡化,語意等價。
- `get_performance_trend` 採 `days`(預設 30)對齊實際 service `GetLatestTrend(days)`,而非規格初稿的 `range`。
- 前置 commit `000032` migration 已套用至 dev 與 test DB。

## 不在範圍內

- 寫入工具 + dry-run/confirmation guardrails + fail-closed 稽核 — Phase 2,另開 issue
- HTTP API、auth、API key 子系統