### PR TITLE
feat: MCP agent 存取 Phase 2（寫入工具 + 安全護欄）

### DIFF
--- a/backend/cmd/mcp/README.md
+++ b/backend/cmd/mcp/README.md
@@ -1,10 +1,26 @@
-# MCP Server (Phase 1 — read-only)
+# MCP Server
 
-An in-process Model Context Protocol server that lets AI agents read portfolio
-data. It speaks MCP over **stdio** and reuses the same database and service
-layer as the API (no HTTP, no API keys). **Phase 1 is read-only** — there are
-no write tools (creating/updating/deleting transactions or reconciliation is
-Phase 2 and intentionally unavailable).
+An in-process Model Context Protocol server that lets AI agents read and modify
+portfolio data. It speaks MCP over **stdio** and reuses the same database and
+service layer as the API (no HTTP, no API keys). Phase 1 added read tools;
+Phase 2 adds write tools behind a dry-run/confirm guardrail with fail-closed
+auditing.
+
+## Write tools (Phase 2)
+
+`create_transaction`, `update_transaction`, `delete_transaction`,
+`reconcile_holding`. Every write tool is **two-step**:
+
+- Without `confirm:true` (default) the tool returns a **dry-run preview** of
+  the effect and persists nothing.
+- With `confirm:true` it executes through the existing service layer (FIFO,
+  realized-profit and reconciliation row-locks preserved).
+
+Writes are **fail-closed audited**: a `pending` row is written to
+`agent_audit_log` *before* the mutation; if that insert fails the write is
+aborted and nothing is persisted. After execution the row is finalized to
+`success`/`error` with `executed_at` set. (Read tools remain best-effort
+audited, per Phase 1.)
 
 ## Tools
 

--- a/backend/cmd/mcp/main.go
+++ b/backend/cmd/mcp/main.go
@@ -59,11 +59,18 @@ func main() {
 	allocationService := service.NewAllocationService(holdingService)
 	performanceTrendService := service.NewPerformanceTrendService(performanceSnapshotRepo, unrealizedAnalyticsService, analyticsService)
 
-	logger := audit.NewLogger(audit.NewPostgresAuditRepository(database))
+	reconcileService := service.NewHoldingReconciliationService(database, transactionRepo, fifoCalculator)
+
+	auditRepo := audit.NewPostgresAuditRepository(database)
+	logger := audit.NewLogger(auditRepo)
+	failClosed := audit.NewFailClosed(auditRepo)
 
 	holdingsAdapter := mcpserver.NewHoldingsAdapter(holdingService)
 	txAdapter := mcpserver.NewTransactionsAdapter(transactionService)
+	txWriteAdapter := mcpserver.NewTxWriteAdapter(transactionService)
+	reconcileAdapter := mcpserver.NewReconcileAdapter(reconcileService)
 	tools := []mcpserver.Tool{
+		// read (Phase 1)
 		mcpserver.NewGetHoldingsTool(holdingsAdapter),
 		mcpserver.NewGetHoldingTool(holdingsAdapter),
 		mcpserver.NewListTransactionsTool(txAdapter),
@@ -71,6 +78,11 @@ func main() {
 		mcpserver.NewGetAnalyticsTool(mcpserver.NewAnalyticsAdapter(analyticsService)),
 		mcpserver.NewGetAllocationTool(mcpserver.NewAllocationAdapter(allocationService)),
 		mcpserver.NewGetPerformanceTrendTool(mcpserver.NewTrendAdapter(performanceTrendService)),
+		// write (Phase 2, dry-run/confirm + fail-closed audit)
+		mcpserver.NewCreateTransactionTool(txWriteAdapter, failClosed),
+		mcpserver.NewUpdateTransactionTool(txWriteAdapter, failClosed),
+		mcpserver.NewDeleteTransactionTool(txWriteAdapter, failClosed),
+		mcpserver.NewReconcileHoldingTool(reconcileAdapter, failClosed),
 	}
 
 	dispatcher := mcpserver.NewDispatcher(tools, mcpserver.NewLoggerSink(logger))

--- a/backend/internal/audit/audit.go
+++ b/backend/internal/audit/audit.go
@@ -34,3 +34,31 @@ func (l *Logger) Record(e Entry) {
 		log.Printf("audit: failed to record %s: %v", e.Tool, err)
 	}
 }
+
+// WriteAuditRepo is the fail-closed lifecycle for mutating tools.
+type WriteAuditRepo interface {
+	Begin(tool string, args []byte) (id string, err error)
+	Finish(id, status, errMsg string, summary []byte, durationMS int) error
+}
+
+// FailClosed enforces audit-before-mutate: a write tool calls Begin and must
+// abort if it errors (nothing is mutated without an audit row). Finish records
+// the outcome; a Finish failure cannot un-do a completed write, so it is
+// logged but not fatal — only Begin gates the operation.
+type FailClosed struct {
+	repo WriteAuditRepo
+}
+
+func NewFailClosed(repo WriteAuditRepo) *FailClosed {
+	return &FailClosed{repo: repo}
+}
+
+func (f *FailClosed) Begin(tool string, args []byte) (string, error) {
+	return f.repo.Begin(tool, args)
+}
+
+func (f *FailClosed) Finish(id, status, errMsg string, summary []byte, durationMS int) {
+	if err := f.repo.Finish(id, status, errMsg, summary, durationMS); err != nil {
+		log.Printf("audit: failed to finalize %s: %v", id, err)
+	}
+}

--- a/backend/internal/audit/audit_repository.go
+++ b/backend/internal/audit/audit_repository.go
@@ -30,3 +30,37 @@ func (r *PostgresAuditRepository) Record(e Entry) error {
 	)
 	return err
 }
+
+// Begin inserts a 'pending' row for a mutating tool and returns its id.
+// A failure here must abort the write (fail-closed), so the error is returned.
+func (r *PostgresAuditRepository) Begin(tool string, args []byte) (string, error) {
+	if len(args) == 0 {
+		args = []byte("{}")
+	}
+	var id string
+	err := r.db.QueryRow(
+		`INSERT INTO agent_audit_log (tool, arguments, status, duration_ms)
+		 VALUES ($1, $2, 'pending', 0) RETURNING id`,
+		tool, args,
+	).Scan(&id)
+	return id, err
+}
+
+// Finish updates a previously-Begun row with the outcome.
+func (r *PostgresAuditRepository) Finish(id, status, errMsg string, summary []byte, durationMS int) error {
+	var errText any
+	if errMsg != "" {
+		errText = errMsg
+	}
+	var sum any
+	if len(summary) > 0 {
+		sum = summary
+	}
+	_, err := r.db.Exec(
+		`UPDATE agent_audit_log
+		 SET status=$2, error=$3, result_summary=$4, duration_ms=$5, executed_at=now()
+		 WHERE id=$1`,
+		id, status, errText, sum, durationMS,
+	)
+	return err
+}

--- a/backend/internal/audit/audit_repository_test.go
+++ b/backend/internal/audit/audit_repository_test.go
@@ -77,3 +77,33 @@ func TestPostgresAuditRepository_RecordError(t *testing.T) {
 	assert.Equal(t, "error", status)
 	assert.Equal(t, "symbol not found", errText)
 }
+
+func TestPostgresAuditRepository_BeginFinishLifecycle(t *testing.T) {
+	db := testDB(t)
+	defer db.Close()
+	_, err := db.Exec("DELETE FROM agent_audit_log")
+	require.NoError(t, err)
+
+	repo := NewPostgresAuditRepository(db)
+	id, err := repo.Begin("create_transaction", []byte(`{"symbol":"2330"}`))
+	require.NoError(t, err)
+	require.NotEmpty(t, id)
+
+	var status string
+	var executedAt sql.NullTime
+	require.NoError(t, db.QueryRow(
+		"SELECT status, executed_at FROM agent_audit_log WHERE id=$1", id,
+	).Scan(&status, &executedAt))
+	assert.Equal(t, "pending", status)
+	assert.False(t, executedAt.Valid, "executed_at should be null while pending")
+
+	require.NoError(t, repo.Finish(id, "success", "", []byte(`{"id":"x"}`), 17))
+
+	var dur int
+	require.NoError(t, db.QueryRow(
+		"SELECT status, duration_ms, executed_at FROM agent_audit_log WHERE id=$1", id,
+	).Scan(&status, &dur, &executedAt))
+	assert.Equal(t, "success", status)
+	assert.Equal(t, 17, dur)
+	assert.True(t, executedAt.Valid, "executed_at set after Finish")
+}

--- a/backend/internal/mcpserver/server.go
+++ b/backend/internal/mcpserver/server.go
@@ -46,6 +46,11 @@ func NewDispatcher(tools []Tool, a auditSink) *Dispatcher {
 	return &Dispatcher{tools: m, audit: a}
 }
 
+// SelfAudited marks tools that own their audit lifecycle (the fail-closed
+// write tools). The Dispatcher must NOT also best-effort log them, or every
+// mutation would produce two audit rows.
+type SelfAudited interface{ selfAudited() }
+
 func (d *Dispatcher) Dispatch(name string, args json.RawMessage) (json.RawMessage, error) {
 	start := time.Now()
 	tool, ok := d.tools[name]
@@ -53,12 +58,17 @@ func (d *Dispatcher) Dispatch(name string, args json.RawMessage) (json.RawMessag
 		d.audit.Record(name, "error", args, nil, ms(start), "unknown tool")
 		return nil, fmt.Errorf("unknown tool: %s", name)
 	}
+	_, selfAudits := tool.(SelfAudited)
 	payload, summary, err := tool.Run(args)
 	if err != nil {
-		d.audit.Record(name, "error", args, nil, ms(start), err.Error())
+		if !selfAudits {
+			d.audit.Record(name, "error", args, nil, ms(start), err.Error())
+		}
 		return nil, err
 	}
-	d.audit.Record(name, "success", args, summary, ms(start), "")
+	if !selfAudits {
+		d.audit.Record(name, "success", args, summary, ms(start), "")
+	}
 	return payload, nil
 }
 

--- a/backend/internal/mcpserver/server_write_integration_test.go
+++ b/backend/internal/mcpserver/server_write_integration_test.go
@@ -1,0 +1,61 @@
+package mcpserver
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/chienchuanw/asset-manager/internal/audit"
+	"github.com/chienchuanw/asset-manager/internal/models"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// create_transaction with confirm:true, real Postgres audit repo, fake tx
+// service: asserts the fail-closed lifecycle wrote a pending row that was
+// finalized to success with executed_at set.
+func TestCreateTransaction_ConfirmWritesAuditRowToDB(t *testing.T) {
+	db := testDB(t)
+	defer db.Close()
+	_, err := db.Exec("DELETE FROM agent_audit_log")
+	require.NoError(t, err)
+
+	w := &recordingTxWriter{tx: &models.Transaction{ID: uuid.New(), Symbol: "2330"}}
+	fc := audit.NewFailClosed(audit.NewPostgresAuditRepository(db))
+	tool := NewCreateTransactionTool(NewTxWriteAdapter(w), fc)
+
+	_, _, err = tool.Run(json.RawMessage(
+		`{"confirm":true,"date":"2026-05-18T00:00:00Z","asset_type":"tw-stock","symbol":"2330","name":"TSMC","type":"buy","quantity":1,"price":1,"amount":1,"currency":"TWD"}`))
+	require.NoError(t, err)
+	assert.True(t, w.createCalled)
+
+	var tool_, status string
+	var executedAtValid bool
+	require.NoError(t, db.QueryRow(
+		`SELECT tool, status, executed_at IS NOT NULL FROM agent_audit_log WHERE tool='create_transaction' LIMIT 1`,
+	).Scan(&tool_, &status, &executedAtValid))
+	assert.Equal(t, "create_transaction", tool_)
+	assert.Equal(t, "success", status)
+	assert.True(t, executedAtValid, "executed_at set after commit")
+}
+
+// Dry run must leave the audit table empty (no mutation, no audit row).
+func TestCreateTransaction_DryRunWritesNoAuditRow(t *testing.T) {
+	db := testDB(t)
+	defer db.Close()
+	_, err := db.Exec("DELETE FROM agent_audit_log")
+	require.NoError(t, err)
+
+	w := &recordingTxWriter{tx: &models.Transaction{ID: uuid.New()}}
+	fc := audit.NewFailClosed(audit.NewPostgresAuditRepository(db))
+	tool := NewCreateTransactionTool(NewTxWriteAdapter(w), fc)
+
+	_, _, err = tool.Run(json.RawMessage(
+		`{"date":"2026-05-18T00:00:00Z","asset_type":"tw-stock","symbol":"2330","name":"TSMC","type":"buy","quantity":1,"price":1,"amount":1,"currency":"TWD"}`))
+	require.NoError(t, err)
+
+	var n int
+	require.NoError(t, db.QueryRow("SELECT count(*) FROM agent_audit_log").Scan(&n))
+	assert.Equal(t, 0, n, "dry run must not write an audit row")
+	assert.False(t, w.createCalled)
+}

--- a/backend/internal/mcpserver/tools_write.go
+++ b/backend/internal/mcpserver/tools_write.go
@@ -1,0 +1,249 @@
+package mcpserver
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/chienchuanw/asset-manager/internal/audit"
+	"github.com/chienchuanw/asset-manager/internal/models"
+)
+
+// previewSummary marks an audit-free dry-run result.
+func previewSummary() json.RawMessage { return json.RawMessage(`{"mode":"preview"}`) }
+
+// commitAudited runs a mutation under the fail-closed audit lifecycle:
+// Begin a pending row first — if that fails the mutation is aborted and
+// nothing is persisted — then execute, then Finish with the outcome.
+func commitAudited(
+	fc *audit.FailClosed,
+	tool string,
+	raw json.RawMessage,
+	exec func() (payload json.RawMessage, summary json.RawMessage, err error),
+) (json.RawMessage, json.RawMessage, error) {
+	start := time.Now()
+	id, err := fc.Begin(tool, []byte(raw))
+	if err != nil {
+		return nil, nil, fmt.Errorf("audit unavailable, write aborted: %w", err)
+	}
+	payload, summary, execErr := exec()
+	dur := int(time.Since(start).Milliseconds())
+	if execErr != nil {
+		fc.Finish(id, "error", execErr.Error(), nil, dur)
+		return nil, nil, execErr
+	}
+	fc.Finish(id, "success", "", summary, dur)
+	return payload, summary, nil
+}
+
+// --- create_transaction ---
+
+type createTxArgs struct {
+	models.CreateTransactionInput
+	Confirm bool `json:"confirm"`
+}
+
+type createTransactionTool struct {
+	port *TxWriteAdapter
+	fc   *audit.FailClosed
+}
+
+func NewCreateTransactionTool(p *TxWriteAdapter, fc *audit.FailClosed) Tool {
+	return &createTransactionTool{p, fc}
+}
+func (t *createTransactionTool) Name() string  { return "create_transaction" }
+func (t *createTransactionTool) selfAudited()  {}
+
+func (t *createTransactionTool) Run(raw json.RawMessage) (json.RawMessage, json.RawMessage, error) {
+	var a createTxArgs
+	if err := json.Unmarshal(raw, &a); err != nil {
+		return nil, nil, fmt.Errorf("invalid arguments: %w", err)
+	}
+	if a.Symbol == "" || a.AssetType == "" || a.TransactionType == "" || a.Currency == "" {
+		return nil, nil, fmt.Errorf("symbol, asset_type, type and currency are required")
+	}
+	if a.Date.IsZero() {
+		return nil, nil, fmt.Errorf("date is required (RFC3339)")
+	}
+	in := a.CreateTransactionInput
+	if !a.Confirm {
+		p, err := json.Marshal(map[string]any{
+			"would_create": in,
+			"note":         "dry run — pass confirm:true to persist",
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+		return p, previewSummary(), nil
+	}
+	return commitAudited(t.fc, t.Name(), raw, func() (json.RawMessage, json.RawMessage, error) {
+		tx, err := t.port.Create(&in)
+		if err != nil {
+			return nil, nil, err
+		}
+		p, mErr := json.Marshal(tx)
+		if mErr != nil {
+			return nil, nil, mErr
+		}
+		return p, json.RawMessage(fmt.Sprintf(`{"created":%q}`, tx.ID.String())), nil
+	})
+}
+
+// --- update_transaction ---
+
+type updateTxArgs struct {
+	ID      string `json:"id"`
+	Confirm bool   `json:"confirm"`
+	models.UpdateTransactionInput
+}
+
+type updateTransactionTool struct {
+	port *TxWriteAdapter
+	fc   *audit.FailClosed
+}
+
+func NewUpdateTransactionTool(p *TxWriteAdapter, fc *audit.FailClosed) Tool {
+	return &updateTransactionTool{p, fc}
+}
+func (t *updateTransactionTool) Name() string { return "update_transaction" }
+func (t *updateTransactionTool) selfAudited() {}
+
+func (t *updateTransactionTool) Run(raw json.RawMessage) (json.RawMessage, json.RawMessage, error) {
+	var a updateTxArgs
+	if err := json.Unmarshal(raw, &a); err != nil {
+		return nil, nil, fmt.Errorf("invalid arguments: %w", err)
+	}
+	if a.ID == "" {
+		return nil, nil, fmt.Errorf("id is required")
+	}
+	in := a.UpdateTransactionInput
+	if !a.Confirm {
+		current, err := t.port.Get(a.ID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("transaction %q not found: %w", a.ID, err)
+		}
+		p, mErr := json.Marshal(map[string]any{
+			"current":          current,
+			"proposed_changes": in,
+			"note":             "dry run — pass confirm:true to apply",
+		})
+		if mErr != nil {
+			return nil, nil, mErr
+		}
+		return p, previewSummary(), nil
+	}
+	return commitAudited(t.fc, t.Name(), raw, func() (json.RawMessage, json.RawMessage, error) {
+		tx, err := t.port.Update(a.ID, &in)
+		if err != nil {
+			return nil, nil, err
+		}
+		p, mErr := json.Marshal(tx)
+		if mErr != nil {
+			return nil, nil, mErr
+		}
+		return p, json.RawMessage(fmt.Sprintf(`{"updated":%q}`, a.ID)), nil
+	})
+}
+
+// --- delete_transaction ---
+
+type deleteTxArgs struct {
+	ID      string `json:"id"`
+	Confirm bool   `json:"confirm"`
+}
+
+type deleteTransactionTool struct {
+	port *TxWriteAdapter
+	fc   *audit.FailClosed
+}
+
+func NewDeleteTransactionTool(p *TxWriteAdapter, fc *audit.FailClosed) Tool {
+	return &deleteTransactionTool{p, fc}
+}
+func (t *deleteTransactionTool) Name() string { return "delete_transaction" }
+func (t *deleteTransactionTool) selfAudited() {}
+
+func (t *deleteTransactionTool) Run(raw json.RawMessage) (json.RawMessage, json.RawMessage, error) {
+	var a deleteTxArgs
+	if err := json.Unmarshal(raw, &a); err != nil {
+		return nil, nil, fmt.Errorf("invalid arguments: %w", err)
+	}
+	if a.ID == "" {
+		return nil, nil, fmt.Errorf("id is required")
+	}
+	if !a.Confirm {
+		current, err := t.port.Get(a.ID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("transaction %q not found: %w", a.ID, err)
+		}
+		p, mErr := json.Marshal(map[string]any{
+			"would_delete": current,
+			"note":         "dry run — pass confirm:true to delete",
+		})
+		if mErr != nil {
+			return nil, nil, mErr
+		}
+		return p, previewSummary(), nil
+	}
+	return commitAudited(t.fc, t.Name(), raw, func() (json.RawMessage, json.RawMessage, error) {
+		if err := t.port.Delete(a.ID); err != nil {
+			return nil, nil, err
+		}
+		return json.RawMessage(fmt.Sprintf(`{"deleted":%q}`, a.ID)),
+			json.RawMessage(fmt.Sprintf(`{"deleted":%q}`, a.ID)), nil
+	})
+}
+
+// --- reconcile_holding ---
+
+type reconcileArgs struct {
+	Items   []models.HoldingReconcileItem `json:"items"`
+	Confirm bool                          `json:"confirm"`
+}
+
+type reconcileHoldingTool struct {
+	port *ReconcileAdapter
+	fc   *audit.FailClosed
+}
+
+func NewReconcileHoldingTool(p *ReconcileAdapter, fc *audit.FailClosed) Tool {
+	return &reconcileHoldingTool{p, fc}
+}
+func (t *reconcileHoldingTool) Name() string { return "reconcile_holding" }
+func (t *reconcileHoldingTool) selfAudited() {}
+
+func (t *reconcileHoldingTool) Run(raw json.RawMessage) (json.RawMessage, json.RawMessage, error) {
+	var a reconcileArgs
+	if err := json.Unmarshal(raw, &a); err != nil {
+		return nil, nil, fmt.Errorf("invalid arguments: %w", err)
+	}
+	if len(a.Items) == 0 {
+		return nil, nil, fmt.Errorf("items is required and must be non-empty")
+	}
+	if !a.Confirm {
+		// The service's own dryRun computes the diff WITHOUT writing.
+		prev, err := t.port.Reconcile(a.Items, true)
+		if err != nil {
+			return nil, nil, err
+		}
+		p, mErr := json.Marshal(map[string]any{
+			"preview": prev,
+			"note":    "dry run — pass confirm:true to write adjustments",
+		})
+		if mErr != nil {
+			return nil, nil, mErr
+		}
+		return p, previewSummary(), nil
+	}
+	return commitAudited(t.fc, t.Name(), raw, func() (json.RawMessage, json.RawMessage, error) {
+		prev, err := t.port.Reconcile(a.Items, false)
+		if err != nil {
+			return nil, nil, err
+		}
+		p, mErr := json.Marshal(prev)
+		if mErr != nil {
+			return nil, nil, mErr
+		}
+		return p, json.RawMessage(fmt.Sprintf(`{"reconciled_items":%d}`, len(a.Items))), nil
+	})
+}

--- a/backend/internal/mcpserver/tools_write_test.go
+++ b/backend/internal/mcpserver/tools_write_test.go
@@ -1,0 +1,165 @@
+package mcpserver
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/chienchuanw/asset-manager/internal/audit"
+	"github.com/chienchuanw/asset-manager/internal/models"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- fakes ---
+
+type recordingTxWriter struct {
+	createCalled, updateCalled, deleteCalled bool
+	tx                                       *models.Transaction
+	err                                      error
+}
+
+func (f *recordingTxWriter) CreateTransaction(*models.CreateTransactionInput) (*models.Transaction, error) {
+	f.createCalled = true
+	return f.tx, f.err
+}
+func (f *recordingTxWriter) UpdateTransaction(uuid.UUID, *models.UpdateTransactionInput) (*models.Transaction, error) {
+	f.updateCalled = true
+	return f.tx, f.err
+}
+func (f *recordingTxWriter) DeleteTransaction(uuid.UUID) error {
+	f.deleteCalled = true
+	return f.err
+}
+func (f *recordingTxWriter) GetTransaction(uuid.UUID) (*models.Transaction, error) {
+	return f.tx, nil
+}
+
+type fakeWriteAuditRepo struct {
+	beginErr    error
+	begun       bool
+	finished    bool
+	finalStatus string
+}
+
+func (f *fakeWriteAuditRepo) Begin(string, []byte) (string, error) {
+	if f.beginErr != nil {
+		return "", f.beginErr
+	}
+	f.begun = true
+	return "audit-id-1", nil
+}
+func (f *fakeWriteAuditRepo) Finish(_, status, _ string, _ []byte, _ int) error {
+	f.finished = true
+	f.finalStatus = status
+	return nil
+}
+
+func newTx() *models.Transaction {
+	return &models.Transaction{ID: uuid.New(), Symbol: "2330"}
+}
+
+// --- dry-run persists nothing ---
+
+func TestCreateTransaction_DryRunDoesNotMutateOrAudit(t *testing.T) {
+	w := &recordingTxWriter{tx: newTx()}
+	ar := &fakeWriteAuditRepo{}
+	tool := NewCreateTransactionTool(NewTxWriteAdapter(w), audit.NewFailClosed(ar))
+
+	_, summary, err := tool.Run(json.RawMessage(
+		`{"date":"2026-05-18T00:00:00Z","asset_type":"tw-stock","symbol":"2330","name":"TSMC","type":"buy","quantity":1,"price":1,"amount":1,"currency":"TWD"}`))
+
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"mode":"preview"}`, string(summary))
+	assert.False(t, w.createCalled, "service must not be called on dry run")
+	assert.False(t, ar.begun, "no audit row on dry run")
+}
+
+// --- confirm path mutates + audits success ---
+
+func TestCreateTransaction_ConfirmMutatesAndAudits(t *testing.T) {
+	w := &recordingTxWriter{tx: newTx()}
+	ar := &fakeWriteAuditRepo{}
+	tool := NewCreateTransactionTool(NewTxWriteAdapter(w), audit.NewFailClosed(ar))
+
+	_, _, err := tool.Run(json.RawMessage(
+		`{"confirm":true,"date":"2026-05-18T00:00:00Z","asset_type":"tw-stock","symbol":"2330","name":"TSMC","type":"buy","quantity":1,"price":1,"amount":1,"currency":"TWD"}`))
+
+	require.NoError(t, err)
+	assert.True(t, w.createCalled)
+	assert.True(t, ar.begun)
+	assert.True(t, ar.finished)
+	assert.Equal(t, "success", ar.finalStatus)
+}
+
+// --- fail-closed: Begin failure aborts before mutating ---
+
+func TestCreateTransaction_AuditBeginFailureAbortsWrite(t *testing.T) {
+	w := &recordingTxWriter{tx: newTx()}
+	ar := &fakeWriteAuditRepo{beginErr: errors.New("db down")}
+	tool := NewCreateTransactionTool(NewTxWriteAdapter(w), audit.NewFailClosed(ar))
+
+	_, _, err := tool.Run(json.RawMessage(
+		`{"confirm":true,"date":"2026-05-18T00:00:00Z","asset_type":"tw-stock","symbol":"2330","name":"TSMC","type":"buy","quantity":1,"price":1,"amount":1,"currency":"TWD"}`))
+
+	assert.ErrorContains(t, err, "write aborted")
+	assert.False(t, w.createCalled, "service must NOT be called when audit Begin fails")
+}
+
+// --- service error is audited as error ---
+
+func TestCreateTransaction_ServiceErrorAuditedAsError(t *testing.T) {
+	w := &recordingTxWriter{err: errors.New("fifo violation")}
+	ar := &fakeWriteAuditRepo{}
+	tool := NewCreateTransactionTool(NewTxWriteAdapter(w), audit.NewFailClosed(ar))
+
+	_, _, err := tool.Run(json.RawMessage(
+		`{"confirm":true,"date":"2026-05-18T00:00:00Z","asset_type":"tw-stock","symbol":"2330","name":"TSMC","type":"buy","quantity":1,"price":1,"amount":1,"currency":"TWD"}`))
+
+	assert.ErrorContains(t, err, "fifo")
+	assert.True(t, ar.finished)
+	assert.Equal(t, "error", ar.finalStatus)
+}
+
+func TestDeleteTransaction_DryRunDoesNotDelete(t *testing.T) {
+	w := &recordingTxWriter{tx: newTx()}
+	ar := &fakeWriteAuditRepo{}
+	tool := NewDeleteTransactionTool(NewTxWriteAdapter(w), audit.NewFailClosed(ar))
+
+	id := w.tx.ID.String()
+	_, summary, err := tool.Run(json.RawMessage(`{"id":"` + id + `"}`))
+
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"mode":"preview"}`, string(summary))
+	assert.False(t, w.deleteCalled)
+}
+
+func TestReconcileHolding_DryRunUsesServiceDryRun(t *testing.T) {
+	rec := &fakeReconciler{}
+	ar := &fakeWriteAuditRepo{}
+	tool := NewReconcileHoldingTool(NewReconcileAdapter(rec), audit.NewFailClosed(ar))
+
+	_, summary, err := tool.Run(json.RawMessage(
+		`{"items":[{"symbol":"2330"}]}`))
+
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"mode":"preview"}`, string(summary))
+	assert.True(t, rec.called)
+	assert.True(t, rec.gotDryRun, "preview must call service with dryRun=true")
+	assert.False(t, ar.begun, "no fail-closed audit on preview")
+}
+
+func TestReconcileHolding_ConfirmWritesAndAudits(t *testing.T) {
+	rec := &fakeReconciler{}
+	ar := &fakeWriteAuditRepo{}
+	tool := NewReconcileHoldingTool(NewReconcileAdapter(rec), audit.NewFailClosed(ar))
+
+	_, _, err := tool.Run(json.RawMessage(
+		`{"confirm":true,"items":[{"symbol":"2330"}]}`))
+
+	require.NoError(t, err)
+	assert.True(t, rec.called)
+	assert.False(t, rec.gotDryRun, "commit must call service with dryRun=false")
+	assert.Equal(t, "success", ar.finalStatus)
+}

--- a/backend/internal/mcpserver/writeadapters.go
+++ b/backend/internal/mcpserver/writeadapters.go
@@ -1,0 +1,66 @@
+package mcpserver
+
+import (
+	"context"
+
+	"github.com/chienchuanw/asset-manager/internal/models"
+	"github.com/google/uuid"
+)
+
+// --- transaction writes ---
+
+type txWriter interface {
+	CreateTransaction(*models.CreateTransactionInput) (*models.Transaction, error)
+	UpdateTransaction(uuid.UUID, *models.UpdateTransactionInput) (*models.Transaction, error)
+	DeleteTransaction(uuid.UUID) error
+	GetTransaction(uuid.UUID) (*models.Transaction, error)
+}
+
+type TxWriteAdapter struct{ svc txWriter }
+
+func NewTxWriteAdapter(svc txWriter) *TxWriteAdapter { return &TxWriteAdapter{svc: svc} }
+
+func (a *TxWriteAdapter) Create(in *models.CreateTransactionInput) (*models.Transaction, error) {
+	return a.svc.CreateTransaction(in)
+}
+
+func (a *TxWriteAdapter) Update(id string, in *models.UpdateTransactionInput) (*models.Transaction, error) {
+	uid, err := uuid.Parse(id)
+	if err != nil {
+		return nil, err
+	}
+	return a.svc.UpdateTransaction(uid, in)
+}
+
+func (a *TxWriteAdapter) Delete(id string) error {
+	uid, err := uuid.Parse(id)
+	if err != nil {
+		return err
+	}
+	return a.svc.DeleteTransaction(uid)
+}
+
+// Get is used to build a delete/update preview (what would change).
+func (a *TxWriteAdapter) Get(id string) (*models.Transaction, error) {
+	uid, err := uuid.Parse(id)
+	if err != nil {
+		return nil, err
+	}
+	return a.svc.GetTransaction(uid)
+}
+
+// --- holding reconciliation ---
+
+type reconciler interface {
+	ReconcileHoldings(context.Context, []models.HoldingReconcileItem, bool) (*models.HoldingReconcilePreview, error)
+}
+
+type ReconcileAdapter struct{ svc reconciler }
+
+func NewReconcileAdapter(svc reconciler) *ReconcileAdapter { return &ReconcileAdapter{svc: svc} }
+
+// Reconcile delegates to the service whose own dryRun flag returns a preview
+// (true) or writes adjustments inside a single DB transaction (false).
+func (a *ReconcileAdapter) Reconcile(items []models.HoldingReconcileItem, dryRun bool) (*models.HoldingReconcilePreview, error) {
+	return a.svc.ReconcileHoldings(context.Background(), items, dryRun)
+}

--- a/backend/internal/mcpserver/writeadapters_test.go
+++ b/backend/internal/mcpserver/writeadapters_test.go
@@ -1,0 +1,70 @@
+package mcpserver
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/chienchuanw/asset-manager/internal/models"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeTxWriter struct {
+	created *models.Transaction
+	err     error
+	deleted bool
+}
+
+func (f *fakeTxWriter) CreateTransaction(*models.CreateTransactionInput) (*models.Transaction, error) {
+	return f.created, f.err
+}
+func (f *fakeTxWriter) UpdateTransaction(uuid.UUID, *models.UpdateTransactionInput) (*models.Transaction, error) {
+	return f.created, f.err
+}
+func (f *fakeTxWriter) DeleteTransaction(uuid.UUID) error { f.deleted = true; return f.err }
+func (f *fakeTxWriter) GetTransaction(uuid.UUID) (*models.Transaction, error) {
+	return f.created, f.err
+}
+
+func TestTxWriteAdapter_Create(t *testing.T) {
+	a := NewTxWriteAdapter(&fakeTxWriter{created: &models.Transaction{Symbol: "2330"}})
+	tx, err := a.Create(&models.CreateTransactionInput{Symbol: "2330"})
+	require.NoError(t, err)
+	assert.Equal(t, "2330", tx.Symbol)
+}
+
+func TestTxWriteAdapter_DeleteInvalidUUID(t *testing.T) {
+	f := &fakeTxWriter{}
+	a := NewTxWriteAdapter(f)
+	err := a.Delete("not-a-uuid")
+	assert.Error(t, err)
+	assert.False(t, f.deleted, "service must not be called on bad uuid")
+}
+
+func TestTxWriteAdapter_CreateError(t *testing.T) {
+	a := NewTxWriteAdapter(&fakeTxWriter{err: errors.New("fifo violation")})
+	_, err := a.Create(&models.CreateTransactionInput{})
+	assert.ErrorContains(t, err, "fifo")
+}
+
+type fakeReconciler struct {
+	gotDryRun bool
+	called    bool
+}
+
+func (f *fakeReconciler) ReconcileHoldings(_ context.Context, _ []models.HoldingReconcileItem, dryRun bool) (*models.HoldingReconcilePreview, error) {
+	f.called = true
+	f.gotDryRun = dryRun
+	return &models.HoldingReconcilePreview{}, nil
+}
+
+func TestReconcileAdapter_PassesDryRunFlag(t *testing.T) {
+	f := &fakeReconciler{}
+	a := NewReconcileAdapter(f)
+	_, err := a.Reconcile(nil, true)
+	require.NoError(t, err)
+	assert.True(t, f.called)
+	assert.True(t, f.gotDryRun)
+}

--- a/backend/migrations/000033_agent_audit_log_pending.down.sql
+++ b/backend/migrations/000033_agent_audit_log_pending.down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE agent_audit_log DROP COLUMN IF EXISTS executed_at;
+ALTER TABLE agent_audit_log DROP CONSTRAINT IF EXISTS agent_audit_log_status_check;
+ALTER TABLE agent_audit_log
+    ADD CONSTRAINT agent_audit_log_status_check
+    CHECK (status IN ('success', 'error'));

--- a/backend/migrations/000033_agent_audit_log_pending.up.sql
+++ b/backend/migrations/000033_agent_audit_log_pending.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE agent_audit_log DROP CONSTRAINT IF EXISTS agent_audit_log_status_check;
+ALTER TABLE agent_audit_log
+    ADD CONSTRAINT agent_audit_log_status_check
+    CHECK (status IN ('success', 'error', 'pending'));
+ALTER TABLE agent_audit_log ADD COLUMN IF NOT EXISTS executed_at TIMESTAMPTZ;


### PR DESCRIPTION
## 摘要

Closes #125

承接 Phase 1(PR #124),新增會變更資料的 MCP 工具,皆經既有 service 層(不繞過 FIFO / row lock),並加上兩段式 dry-run/確認護欄與 fail-closed 稽核。純後端,`internal/service/*` 未變更。

## 變更內容

- **migration `000033`**:`agent_audit_log.status` 放寬允許 `pending`;新增 `executed_at TIMESTAMPTZ`
- **`internal/audit`**:新增 fail-closed 生命週期 — `PostgresAuditRepository.Begin`(寫 pending 列,回傳 id)/`Finish`(更新 status/error/summary/duration + `executed_at=now()`);`FailClosed` 包裝(Begin 失敗即中止;Finish 失敗僅記 log,不可回溯已完成寫入)
- **`internal/mcpserver`**:
  - `writeadapters.go` — `TxWriteAdapter`(Create/Update/Delete/Get)、`ReconcileAdapter`(轉呼服務內建 dryRun)
  - `tools_write.go` — `create_transaction`、`update_transaction`、`delete_transaction`、`reconcile_holding`;`confirm` 缺省→dry-run 預覽不寫入、不稽核;`confirm:true`→經 service 執行 + fail-closed 稽核(`commitAudited`:Begin→exec→Finish)
  - `server.go` — `SelfAudited` 標記介面;Dispatcher 對寫入工具略過 best-effort 記錄(避免雙重稽核)
  - `cmd/mcp/main.go` — 註冊 4 個寫入工具(`NewHoldingReconciliationService` 接線)
- `cmd/mcp/README.md` 更新 Phase 2 說明

## 測試

- `internal/mcpserver` 全綠:寫入工具單元(dry-run 不呼叫 service / commit 呼叫 + 稽核 / **Begin 失敗即中止且未呼叫 service** / service 錯誤稽核為 error)、reconcile preview 走 service dryRun、**DB 整合**(confirm 寫稽核 pending→success + executed_at;dry-run 不留稽核列)
- `internal/audit` 全綠:Begin/Finish lifecycle DB 測試
- `make test-unit`:328 測試全綠(`internal/service/*` 未變更,FIFO/realized-profit/reconciliation 行為不變)
- `go build ./...` 成功

## 設計備註

- reconcile 預覽直接用 `HoldingReconciliationService` 既有 `dryRun=true`(服務保證不寫入),commit 走 `dryRun=false` 並包 fail-closed 稽核。
- dry-run 不產生稽核列(屬非變更操作);唯 commit 受 fail-closed 保護。

## 不在範圍內

- REST / API key 介面;非交易實體(cash-flows/subscriptions);Phase 1 唯讀工具(已交付)