### PR TITLE
feat: FIRE calculator with hybrid auto-prefill projection

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -163,6 +163,8 @@ func main() {
 		rebalanceHandler := api.NewRebalanceHandler(rebalanceService)
 		cashFlowHandler := api.NewCashFlowHandler(cashFlowService)
 		cashFlowHandler.SetDiscordService(discordService) // 設定 Discord service 用於發送報告
+		fireService := service.NewFireService(assetSnapshotService, cashFlowService)
+		fireHandler := api.NewFireHandler(fireService)
 		categoryHandler := api.NewCategoryHandler(categoryService)
 		subscriptionHandler := api.NewSubscriptionHandler(subscriptionService)
 		installmentHandler := api.NewInstallmentHandler(installmentService)
@@ -197,7 +199,7 @@ func main() {
 		// 建立 router 並啟動（簡化版，不啟動排程器）
 		log.Println("Warning: Scheduler is disabled (Redis not available)")
 		bot := startDiscordBot(botCtx, cashFlowService, categoryRepo, bankAccountRepo, creditCardRepo)
-		startServer(authHandler, transactionHandler, holdingHandler, analyticsHandler, unrealizedAnalyticsHandler, allocationHandler, performanceTrendHandler, settingsHandler, assetSnapshotHandler, discordHandler, schedulerHandler, rebalanceHandler, cashFlowHandler, categoryHandler, subscriptionHandler, installmentHandler, billingHandler, bankAccountHandler, creditCardHandler, creditCardGroupHandler, reconciliationHandler, holdingReconcileHandler, exchangeRateHandler, nil, bot)
+		startServer(authHandler, transactionHandler, holdingHandler, analyticsHandler, unrealizedAnalyticsHandler, allocationHandler, performanceTrendHandler, settingsHandler, assetSnapshotHandler, discordHandler, schedulerHandler, rebalanceHandler, cashFlowHandler, categoryHandler, subscriptionHandler, installmentHandler, billingHandler, bankAccountHandler, creditCardHandler, creditCardGroupHandler, reconciliationHandler, holdingReconcileHandler, exchangeRateHandler, fireHandler, nil, bot)
 		return
 	}
 	defer redisCache.Close()
@@ -285,6 +287,8 @@ func main() {
 	rebalanceHandler := api.NewRebalanceHandler(rebalanceService)
 	cashFlowHandler := api.NewCashFlowHandler(cashFlowService)
 	cashFlowHandler.SetDiscordService(discordService) // 設定 Discord service 用於發送報告
+	fireService := service.NewFireService(assetSnapshotService, cashFlowService)
+	fireHandler := api.NewFireHandler(fireService)
 	categoryHandler := api.NewCategoryHandler(categoryService)
 	subscriptionHandler := api.NewSubscriptionHandler(subscriptionService)
 	installmentHandler := api.NewInstallmentHandler(installmentService)
@@ -323,7 +327,7 @@ func main() {
 
 	// 啟動伺服器（會在內部處理 graceful shutdown）
 	bot := startDiscordBot(botCtx, cashFlowService, categoryRepo, bankAccountRepo, creditCardRepo)
-	startServer(authHandler, transactionHandler, holdingHandler, analyticsHandler, unrealizedAnalyticsHandler, allocationHandler, performanceTrendHandler, settingsHandler, assetSnapshotHandler, discordHandler, schedulerHandler, rebalanceHandler, cashFlowHandler, categoryHandler, subscriptionHandler, installmentHandler, billingHandler, bankAccountHandler, creditCardHandler, creditCardGroupHandler, reconciliationHandler, holdingReconcileHandler, exchangeRateHandler, schedulerManager, bot)
+	startServer(authHandler, transactionHandler, holdingHandler, analyticsHandler, unrealizedAnalyticsHandler, allocationHandler, performanceTrendHandler, settingsHandler, assetSnapshotHandler, discordHandler, schedulerHandler, rebalanceHandler, cashFlowHandler, categoryHandler, subscriptionHandler, installmentHandler, billingHandler, bankAccountHandler, creditCardHandler, creditCardGroupHandler, reconciliationHandler, holdingReconcileHandler, exchangeRateHandler, fireHandler, schedulerManager, bot)
 }
 
 // getEnvOrDefault 取得環境變數，如果不存在則使用預設值
@@ -370,7 +374,7 @@ func startDiscordBot(ctx context.Context, cashFlowSvc service.CashFlowService, c
 	return bot
 }
 
-func startServer(authHandler *api.AuthHandler, transactionHandler *api.TransactionHandler, holdingHandler *api.HoldingHandler, analyticsHandler *api.AnalyticsHandler, unrealizedAnalyticsHandler *api.UnrealizedAnalyticsHandler, allocationHandler *api.AllocationHandler, performanceTrendHandler *api.PerformanceTrendHandler, settingsHandler *api.SettingsHandler, assetSnapshotHandler *api.AssetSnapshotHandler, discordHandler *api.DiscordHandler, schedulerHandler *api.SchedulerHandler, rebalanceHandler *api.RebalanceHandler, cashFlowHandler *api.CashFlowHandler, categoryHandler *api.CategoryHandler, subscriptionHandler *api.SubscriptionHandler, installmentHandler *api.InstallmentHandler, billingHandler *api.BillingHandler, bankAccountHandler *api.BankAccountHandler, creditCardHandler *api.CreditCardHandler, creditCardGroupHandler *api.CreditCardGroupHandler, reconciliationHandler *api.ReconciliationHandler, holdingReconcileHandler *api.HoldingReconciliationHandler, exchangeRateHandler *api.ExchangeRateHandler, schedulerManager *scheduler.SchedulerManager, discordBot *discordbot.Bot) {
+func startServer(authHandler *api.AuthHandler, transactionHandler *api.TransactionHandler, holdingHandler *api.HoldingHandler, analyticsHandler *api.AnalyticsHandler, unrealizedAnalyticsHandler *api.UnrealizedAnalyticsHandler, allocationHandler *api.AllocationHandler, performanceTrendHandler *api.PerformanceTrendHandler, settingsHandler *api.SettingsHandler, assetSnapshotHandler *api.AssetSnapshotHandler, discordHandler *api.DiscordHandler, schedulerHandler *api.SchedulerHandler, rebalanceHandler *api.RebalanceHandler, cashFlowHandler *api.CashFlowHandler, categoryHandler *api.CategoryHandler, subscriptionHandler *api.SubscriptionHandler, installmentHandler *api.InstallmentHandler, billingHandler *api.BillingHandler, bankAccountHandler *api.BankAccountHandler, creditCardHandler *api.CreditCardHandler, creditCardGroupHandler *api.CreditCardGroupHandler, reconciliationHandler *api.ReconciliationHandler, holdingReconcileHandler *api.HoldingReconciliationHandler, exchangeRateHandler *api.ExchangeRateHandler, fireHandler *api.FireHandler, schedulerManager *scheduler.SchedulerManager, discordBot *discordbot.Bot) {
 	// 建立 Gin router
 	router := gin.Default()
 
@@ -441,6 +445,12 @@ func startServer(authHandler *api.AuthHandler, transactionHandler *api.Transacti
 		}
 
 		// Analytics 路由
+		// FIRE 路由
+		fire := apiGroup.Group("/fire")
+		{
+			fire.GET("/projection", fireHandler.GetProjection)
+		}
+
 		analytics := apiGroup.Group("/analytics")
 		{
 			analytics.GET("/summary", analyticsHandler.GetSummary)

--- a/backend/internal/api/fire_handler.go
+++ b/backend/internal/api/fire_handler.go
@@ -1,0 +1,81 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/chienchuanw/asset-manager/internal/models"
+	"github.com/chienchuanw/asset-manager/internal/service"
+	"github.com/gin-gonic/gin"
+)
+
+// FireHandler FIRE 投影 API Handler
+type FireHandler struct {
+	fireService service.FireService
+}
+
+// NewFireHandler 建立新的 FireHandler
+func NewFireHandler(fireService service.FireService) *FireHandler {
+	return &FireHandler{fireService: fireService}
+}
+
+// optionalFloatQuery 解析可選的浮點數查詢參數；缺少或無法解析時回傳 nil。
+func optionalFloatQuery(c *gin.Context, key string) *float64 {
+	raw := c.Query(key)
+	if raw == "" {
+		return nil
+	}
+	v, err := strconv.ParseFloat(raw, 64)
+	if err != nil {
+		return nil
+	}
+	return &v
+}
+
+// GetProjection 取得 FIRE 投影
+// @Summary 取得 FIRE 投影
+// @Description 依據自動推導的淨值與現金流（可由查詢參數覆寫）計算 FIRE 數字、進度與達標年數
+// @Tags fire
+// @Accept json
+// @Produce json
+// @Param netWorth query number false "目前淨值（TWD），覆寫最新資產快照"
+// @Param annualExpenses query number false "年支出（TWD），覆寫近 12 個月推導值"
+// @Param annualSavings query number false "年儲蓄（TWD），覆寫近 12 個月推導值"
+// @Param expectedReturn query number false "預期年化報酬率（小數），預設 0.05"
+// @Param withdrawalRate query number false "安全提領率（小數），預設 0.04"
+// @Success 200 {object} models.FireProjectionResult
+// @Failure 400 {object} APIResponse
+// @Failure 500 {object} APIResponse
+// @Router /api/fire/projection [get]
+func (h *FireHandler) GetProjection(c *gin.Context) {
+	input := models.FireProjectionInput{
+		NetWorth:       optionalFloatQuery(c, "netWorth"),
+		AnnualExpenses: optionalFloatQuery(c, "annualExpenses"),
+		AnnualSavings:  optionalFloatQuery(c, "annualSavings"),
+		ExpectedReturn: optionalFloatQuery(c, "expectedReturn"),
+		WithdrawalRate: optionalFloatQuery(c, "withdrawalRate"),
+	}
+
+	result, err := h.fireService.GetProjection(input)
+	if err != nil {
+		if errors.Is(err, service.ErrInvalidWithdrawalRate) {
+			c.JSON(http.StatusBadRequest, APIResponse{
+				Error: &APIError{
+					Code:    "INVALID_WITHDRAWAL_RATE",
+					Message: err.Error(),
+				},
+			})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, APIResponse{
+			Error: &APIError{
+				Code:    "FIRE_PROJECTION_FAILED",
+				Message: err.Error(),
+			},
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, APIResponse{Data: result})
+}

--- a/backend/internal/api/fire_handler_test.go
+++ b/backend/internal/api/fire_handler_test.go
@@ -1,0 +1,128 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/chienchuanw/asset-manager/internal/models"
+	"github.com/chienchuanw/asset-manager/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// MockFireService 模擬的 FireService
+type MockFireService struct {
+	mock.Mock
+}
+
+func (m *MockFireService) GetProjection(input models.FireProjectionInput) (*models.FireProjectionResult, error) {
+	args := m.Called(input)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.FireProjectionResult), args.Error(1)
+}
+
+func setupFireTestRouter(handler *FireHandler) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	api := router.Group("/api")
+	{
+		fire := api.Group("/fire")
+		{
+			fire.GET("/projection", handler.GetProjection)
+		}
+	}
+	return router
+}
+
+func TestFireHandler_GetProjection_HappyPath(t *testing.T) {
+	mockService := new(MockFireService)
+	handler := NewFireHandler(mockService)
+	router := setupFireTestRouter(handler)
+
+	years := 12
+	mockService.On("GetProjection", mock.Anything).Return(&models.FireProjectionResult{
+		FireNumber: 15_000_000,
+		YearsToFI:  &years,
+		OnTrack:    true,
+	}, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/fire/projection", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp APIResponse
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.NotNil(t, resp.Data)
+}
+
+func TestFireHandler_GetProjection_ParsesQueryOverrides(t *testing.T) {
+	mockService := new(MockFireService)
+	handler := NewFireHandler(mockService)
+	router := setupFireTestRouter(handler)
+
+	var captured models.FireProjectionInput
+	mockService.On("GetProjection", mock.Anything).
+		Run(func(args mock.Arguments) {
+			captured = args.Get(0).(models.FireProjectionInput)
+		}).
+		Return(&models.FireProjectionResult{}, nil)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/fire/projection?netWorth=1000000&annualExpenses=600000&annualSavings=500000&expectedReturn=0.06&withdrawalRate=0.035",
+		nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.NotNil(t, captured.NetWorth)
+	assert.Equal(t, 1_000_000.0, *captured.NetWorth)
+	assert.NotNil(t, captured.AnnualExpenses)
+	assert.Equal(t, 600_000.0, *captured.AnnualExpenses)
+	assert.NotNil(t, captured.AnnualSavings)
+	assert.Equal(t, 500_000.0, *captured.AnnualSavings)
+	assert.NotNil(t, captured.ExpectedReturn)
+	assert.InDelta(t, 0.06, *captured.ExpectedReturn, 1e-9)
+	assert.NotNil(t, captured.WithdrawalRate)
+	assert.InDelta(t, 0.035, *captured.WithdrawalRate, 1e-9)
+}
+
+func TestFireHandler_GetProjection_InvalidWithdrawalRateReturns400(t *testing.T) {
+	mockService := new(MockFireService)
+	handler := NewFireHandler(mockService)
+	router := setupFireTestRouter(handler)
+
+	mockService.On("GetProjection", mock.Anything).
+		Return(nil, service.ErrInvalidWithdrawalRate)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/fire/projection?withdrawalRate=0", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestFireHandler_GetProjection_IgnoresUnparseableQueryParams(t *testing.T) {
+	mockService := new(MockFireService)
+	handler := NewFireHandler(mockService)
+	router := setupFireTestRouter(handler)
+
+	var captured models.FireProjectionInput
+	mockService.On("GetProjection", mock.Anything).
+		Run(func(args mock.Arguments) {
+			captured = args.Get(0).(models.FireProjectionInput)
+		}).
+		Return(&models.FireProjectionResult{}, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/fire/projection?netWorth=abc", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Nil(t, captured.NetWorth)
+}

--- a/backend/internal/models/fire.go
+++ b/backend/internal/models/fire.go
@@ -1,0 +1,39 @@
+package models
+
+// FIRE (Financial Independence / Retire Early) 計算預設值
+const (
+	DefaultExpectedReturn = 0.05 // 預設預期年化報酬率 5%
+	DefaultWithdrawalRate = 0.04 // 預設安全提領率 4%
+	MaxProjectionYears    = 60   // 投影年數上限
+)
+
+// FireProjectionInput FIRE 投影輸入；所有欄位皆為可選覆寫值，
+// 未提供時由服務從應用資料自動推導。
+type FireProjectionInput struct {
+	NetWorth       *float64
+	AnnualExpenses *float64
+	AnnualSavings  *float64
+	ExpectedReturn *float64
+	WithdrawalRate *float64
+}
+
+// FireProjectionPoint 投影圖表上的單一資料點
+type FireProjectionPoint struct {
+	Year              int     `json:"year"`
+	ProjectedNetWorth float64 `json:"projected_net_worth"`
+	FireTarget        float64 `json:"fire_target"`
+}
+
+// FireProjectionResult FIRE 投影結果，回傳已套用的輸入值供前端回填表單。
+type FireProjectionResult struct {
+	CurrentNetWorth float64               `json:"current_net_worth"`
+	AnnualExpenses  float64               `json:"annual_expenses"`
+	AnnualSavings   float64               `json:"annual_savings"`
+	ExpectedReturn  float64               `json:"expected_return"`
+	WithdrawalRate  float64               `json:"withdrawal_rate"`
+	FireNumber      float64               `json:"fire_number"`
+	ProgressPct     float64               `json:"progress_pct"`
+	YearsToFI       *int                  `json:"years_to_fi"`
+	OnTrack         bool                  `json:"on_track"`
+	Projection      []FireProjectionPoint `json:"projection"`
+}

--- a/backend/internal/service/fire_service.go
+++ b/backend/internal/service/fire_service.go
@@ -1,0 +1,141 @@
+package service
+
+import (
+	"errors"
+	"time"
+
+	"github.com/chienchuanw/asset-manager/internal/models"
+	"github.com/chienchuanw/asset-manager/internal/repository"
+)
+
+// ErrInvalidWithdrawalRate 提領率必須為正數
+var ErrInvalidWithdrawalRate = errors.New("withdrawal rate must be greater than zero")
+
+// fireNetWorthSource 提供最新淨值快照（介面隔離，僅取所需方法）
+type fireNetWorthSource interface {
+	GetLatestSnapshot(assetType models.SnapshotAssetType) (*models.AssetSnapshot, error)
+}
+
+// fireCashFlowSource 提供現金流摘要（介面隔離，僅取所需方法）
+type fireCashFlowSource interface {
+	GetSummary(startDate, endDate time.Time) (*repository.CashFlowSummary, error)
+}
+
+// FireService FIRE 投影計算服務
+type FireService interface {
+	GetProjection(input models.FireProjectionInput) (*models.FireProjectionResult, error)
+}
+
+type fireService struct {
+	netWorthSource fireNetWorthSource
+	cashFlowSource fireCashFlowSource
+}
+
+// NewFireService 建立 FireService
+func NewFireService(netWorthSource fireNetWorthSource, cashFlowSource fireCashFlowSource) FireService {
+	return &fireService{
+		netWorthSource: netWorthSource,
+		cashFlowSource: cashFlowSource,
+	}
+}
+
+func (s *fireService) GetProjection(input models.FireProjectionInput) (*models.FireProjectionResult, error) {
+	expectedReturn := models.DefaultExpectedReturn
+	if input.ExpectedReturn != nil {
+		expectedReturn = *input.ExpectedReturn
+	}
+
+	withdrawalRate := models.DefaultWithdrawalRate
+	if input.WithdrawalRate != nil {
+		withdrawalRate = *input.WithdrawalRate
+	}
+	if withdrawalRate <= 0 {
+		return nil, ErrInvalidWithdrawalRate
+	}
+
+	// 推導現金流相關預設值僅在需要時查詢一次
+	var summary *repository.CashFlowSummary
+	needSummary := input.AnnualExpenses == nil || input.AnnualSavings == nil
+	if needSummary {
+		end := time.Now()
+		start := end.AddDate(-1, 0, 0)
+		// 摘要查詢失敗時退回 0，不阻斷投影
+		summary, _ = s.cashFlowSource.GetSummary(start, end)
+	}
+
+	annualExpenses := 0.0
+	if input.AnnualExpenses != nil {
+		annualExpenses = *input.AnnualExpenses
+	} else if summary != nil {
+		annualExpenses = summary.TotalExpense
+	}
+
+	annualSavings := 0.0
+	if input.AnnualSavings != nil {
+		annualSavings = *input.AnnualSavings
+	} else if summary != nil {
+		annualSavings = summary.NetCashFlow
+	}
+
+	netWorth := 0.0
+	if input.NetWorth != nil {
+		netWorth = *input.NetWorth
+	} else if snapshot, err := s.netWorthSource.GetLatestSnapshot(models.SnapshotAssetTypeTotal); err == nil && snapshot != nil {
+		netWorth = snapshot.ValueTWD
+	}
+
+	fireNumber := annualExpenses / withdrawalRate
+
+	progressPct := 1.0
+	if fireNumber > 0 {
+		progressPct = netWorth / fireNumber
+	}
+
+	yearsToFI, projection := project(netWorth, fireNumber, annualSavings, expectedReturn)
+
+	return &models.FireProjectionResult{
+		CurrentNetWorth: netWorth,
+		AnnualExpenses:  annualExpenses,
+		AnnualSavings:   annualSavings,
+		ExpectedReturn:  expectedReturn,
+		WithdrawalRate:  withdrawalRate,
+		FireNumber:      fireNumber,
+		ProgressPct:     progressPct,
+		YearsToFI:       yearsToFI,
+		OnTrack:         yearsToFI != nil,
+		Projection:      projection,
+	}, nil
+}
+
+// project 逐年推算淨值，回傳達到 FI 的年數（未達標為 nil）與投影資料點。
+func project(netWorth, fireNumber, annualSavings, expectedReturn float64) (*int, []models.FireProjectionPoint) {
+	projection := []models.FireProjectionPoint{
+		{Year: 0, ProjectedNetWorth: netWorth, FireTarget: fireNumber},
+	}
+
+	if netWorth >= fireNumber {
+		zero := 0
+		return &zero, projection
+	}
+
+	// 無正儲蓄則視為無法達標（依設計規格）
+	if annualSavings <= 0 {
+		return nil, projection
+	}
+
+	nw := netWorth
+	for year := 1; year <= models.MaxProjectionYears; year++ {
+		nw = nw*(1+expectedReturn) + annualSavings
+		projection = append(projection, models.FireProjectionPoint{
+			Year:              year,
+			ProjectedNetWorth: nw,
+			FireTarget:        fireNumber,
+		})
+		if nw >= fireNumber {
+			y := year
+			return &y, projection
+		}
+	}
+
+	return nil, projection
+}

--- a/backend/internal/service/fire_service_test.go
+++ b/backend/internal/service/fire_service_test.go
@@ -1,0 +1,205 @@
+package service
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/chienchuanw/asset-manager/internal/models"
+	"github.com/chienchuanw/asset-manager/internal/repository"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// MockFireNetWorthSource mocks the latest-snapshot dependency
+type MockFireNetWorthSource struct {
+	mock.Mock
+}
+
+func (m *MockFireNetWorthSource) GetLatestSnapshot(assetType models.SnapshotAssetType) (*models.AssetSnapshot, error) {
+	args := m.Called(assetType)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.AssetSnapshot), args.Error(1)
+}
+
+// MockFireCashFlowSource mocks the cash-flow summary dependency
+type MockFireCashFlowSource struct {
+	mock.Mock
+}
+
+func (m *MockFireCashFlowSource) GetSummary(startDate, endDate time.Time) (*repository.CashFlowSummary, error) {
+	args := m.Called(startDate, endDate)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*repository.CashFlowSummary), args.Error(1)
+}
+
+func f(v float64) *float64 { return &v }
+
+func TestFireService_GetProjection_NormalCase(t *testing.T) {
+	nw := new(MockFireNetWorthSource)
+	cf := new(MockFireCashFlowSource)
+	svc := NewFireService(nw, cf)
+
+	in := models.FireProjectionInput{
+		NetWorth:       f(1_000_000),
+		AnnualExpenses: f(600_000),
+		AnnualSavings:  f(500_000),
+		ExpectedReturn: f(0.05),
+		WithdrawalRate: f(0.04),
+	}
+
+	res, err := svc.GetProjection(in)
+
+	assert.NoError(t, err)
+	// fireNumber = 600000 / 0.04 = 15,000,000
+	assert.InDelta(t, 15_000_000, res.FireNumber, 0.01)
+	assert.InDelta(t, 1_000_000.0/15_000_000.0, res.ProgressPct, 0.0001)
+	assert.NotNil(t, res.YearsToFI)
+	assert.True(t, res.OnTrack)
+	assert.NotEmpty(t, res.Projection)
+	// Echoed inputs
+	assert.Equal(t, 1_000_000.0, res.CurrentNetWorth)
+	assert.Equal(t, 600_000.0, res.AnnualExpenses)
+}
+
+func TestFireService_GetProjection_NotOnTrackWhenSavingsNonPositive(t *testing.T) {
+	svc := NewFireService(new(MockFireNetWorthSource), new(MockFireCashFlowSource))
+
+	res, err := svc.GetProjection(models.FireProjectionInput{
+		NetWorth:       f(100_000),
+		AnnualExpenses: f(500_000),
+		AnnualSavings:  f(-1000),
+		WithdrawalRate: f(0.04),
+	})
+
+	assert.NoError(t, err)
+	assert.Nil(t, res.YearsToFI)
+	assert.False(t, res.OnTrack)
+}
+
+func TestFireService_GetProjection_AlreadyFIWhenExpensesZero(t *testing.T) {
+	svc := NewFireService(new(MockFireNetWorthSource), new(MockFireCashFlowSource))
+
+	res, err := svc.GetProjection(models.FireProjectionInput{
+		NetWorth:       f(0),
+		AnnualExpenses: f(0),
+		AnnualSavings:  f(0),
+		WithdrawalRate: f(0.04),
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, 0.0, res.FireNumber)
+	assert.NotNil(t, res.YearsToFI)
+	assert.Equal(t, 0, *res.YearsToFI)
+	assert.True(t, res.OnTrack)
+}
+
+func TestFireService_GetProjection_ZeroReturnLinearGrowth(t *testing.T) {
+	svc := NewFireService(new(MockFireNetWorthSource), new(MockFireCashFlowSource))
+
+	// fireNumber = 100000/0.04 = 2,500,000; nw 500k; savings 500k/yr; r=0
+	// years = ceil((2.5M-0.5M)/0.5M) = 4
+	res, err := svc.GetProjection(models.FireProjectionInput{
+		NetWorth:       f(500_000),
+		AnnualExpenses: f(100_000),
+		AnnualSavings:  f(500_000),
+		ExpectedReturn: f(0),
+		WithdrawalRate: f(0.04),
+	})
+
+	assert.NoError(t, err)
+	assert.NotNil(t, res.YearsToFI)
+	assert.Equal(t, 4, *res.YearsToFI)
+}
+
+func TestFireService_GetProjection_OverridesTakePrecedenceOverDerived(t *testing.T) {
+	nw := new(MockFireNetWorthSource)
+	cf := new(MockFireCashFlowSource)
+	// Derived values that should be ignored because overrides are supplied
+	nw.On("GetLatestSnapshot", models.SnapshotAssetTypeTotal).
+		Return(&models.AssetSnapshot{ValueTWD: 999}, nil)
+	cf.On("GetSummary", mock.Anything, mock.Anything).
+		Return(&repository.CashFlowSummary{TotalExpense: 999, NetCashFlow: 999}, nil)
+
+	svc := NewFireService(nw, cf)
+	res, err := svc.GetProjection(models.FireProjectionInput{
+		NetWorth:       f(1_000_000),
+		AnnualExpenses: f(400_000),
+		AnnualSavings:  f(300_000),
+		WithdrawalRate: f(0.04),
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1_000_000.0, res.CurrentNetWorth)
+	assert.Equal(t, 400_000.0, res.AnnualExpenses)
+	assert.Equal(t, 300_000.0, res.AnnualSavings)
+	nw.AssertNotCalled(t, "GetLatestSnapshot", mock.Anything)
+	cf.AssertNotCalled(t, "GetSummary", mock.Anything, mock.Anything)
+}
+
+func TestFireService_GetProjection_DerivesFromDependenciesWhenNoOverrides(t *testing.T) {
+	nw := new(MockFireNetWorthSource)
+	cf := new(MockFireCashFlowSource)
+	nw.On("GetLatestSnapshot", models.SnapshotAssetTypeTotal).
+		Return(&models.AssetSnapshot{ValueTWD: 2_000_000}, nil)
+	cf.On("GetSummary", mock.Anything, mock.Anything).
+		Return(&repository.CashFlowSummary{TotalExpense: 480_000, NetCashFlow: 360_000}, nil)
+
+	svc := NewFireService(nw, cf)
+	res, err := svc.GetProjection(models.FireProjectionInput{})
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2_000_000.0, res.CurrentNetWorth)
+	assert.Equal(t, 480_000.0, res.AnnualExpenses)
+	assert.Equal(t, 360_000.0, res.AnnualSavings)
+	assert.Equal(t, models.DefaultExpectedReturn, res.ExpectedReturn)
+	assert.Equal(t, models.DefaultWithdrawalRate, res.WithdrawalRate)
+}
+
+func TestFireService_GetProjection_NoSnapshotDefaultsToZeroNetWorth(t *testing.T) {
+	nw := new(MockFireNetWorthSource)
+	cf := new(MockFireCashFlowSource)
+	nw.On("GetLatestSnapshot", models.SnapshotAssetTypeTotal).
+		Return(nil, errors.New("no snapshot"))
+	cf.On("GetSummary", mock.Anything, mock.Anything).
+		Return(&repository.CashFlowSummary{TotalExpense: 300_000, NetCashFlow: 200_000}, nil)
+
+	svc := NewFireService(nw, cf)
+	res, err := svc.GetProjection(models.FireProjectionInput{})
+
+	assert.NoError(t, err)
+	assert.Equal(t, 0.0, res.CurrentNetWorth)
+}
+
+func TestFireService_GetProjection_RejectsNonPositiveWithdrawalRate(t *testing.T) {
+	svc := NewFireService(new(MockFireNetWorthSource), new(MockFireCashFlowSource))
+
+	_, err := svc.GetProjection(models.FireProjectionInput{
+		AnnualExpenses: f(100_000),
+		WithdrawalRate: f(0),
+	})
+
+	assert.Error(t, err)
+}
+
+func TestFireService_GetProjection_CapsProjectionAt60Years(t *testing.T) {
+	svc := NewFireService(new(MockFireNetWorthSource), new(MockFireCashFlowSource))
+
+	// Tiny savings, huge target -> never reached within 60 years
+	res, err := svc.GetProjection(models.FireProjectionInput{
+		NetWorth:       f(0),
+		AnnualExpenses: f(10_000_000),
+		AnnualSavings:  f(1),
+		ExpectedReturn: f(0),
+		WithdrawalRate: f(0.04),
+	})
+
+	assert.NoError(t, err)
+	assert.Nil(t, res.YearsToFI)
+	assert.False(t, res.OnTrack)
+	assert.LessOrEqual(t, len(res.Projection), models.MaxProjectionYears+1)
+}

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -81,7 +81,8 @@
     "notification": "Notifications",
     "mainFeatures": "Main Features",
     "appName": "Asset Manager",
-    "appDescription": "Asset Management System"
+    "appDescription": "Asset Management System",
+    "fire": "FIRE"
   },
   "dashboard": {
     "title": "Dashboard",
@@ -725,5 +726,30 @@
     "loading": "Loading…",
     "errorTitle": "Couldn't load data",
     "retry": "Retry"
+  },
+  "fire": {
+    "title": "FIRE Calculator",
+    "description": "Estimate your financial independence number and progress",
+    "assumptions": "Assumptions",
+    "assumptionsHint": "Leave a field blank to auto-derive it from your data. Placeholders show the current derived value.",
+    "fields": {
+      "netWorth": "Current Net Worth (TWD)",
+      "annualExpenses": "Annual Expenses (TWD)",
+      "annualSavings": "Annual Savings (TWD)",
+      "expectedReturn": "Expected Annual Return",
+      "withdrawalRate": "Withdrawal Rate"
+    },
+    "apply": "Apply",
+    "resetToAuto": "Reset to Auto",
+    "fireNumber": "FIRE Number",
+    "progress": "Progress",
+    "yearsToFI": "Years to FI",
+    "yearsValue": "{years} years",
+    "notOnTrack": "Not on track",
+    "projectionTitle": "Net Worth Projection",
+    "projectionHint": "Projected net worth vs. your FIRE target",
+    "yearAxis": "Y{year}",
+    "noSnapshotTitle": "No net worth data",
+    "noSnapshotHint": "Add an asset snapshot to see a personalized projection, or enter a net worth value above."
   }
 }

--- a/frontend/messages/zh-TW.json
+++ b/frontend/messages/zh-TW.json
@@ -81,7 +81,8 @@
     "notification": "通知管理",
     "mainFeatures": "主要功能",
     "appName": "Asset Manager",
-    "appDescription": "資產管理系統"
+    "appDescription": "資產管理系統",
+    "fire": "FIRE"
   },
   "dashboard": {
     "title": "首頁",
@@ -761,5 +762,30 @@
     "loading": "載入中…",
     "errorTitle": "資料載入失敗",
     "retry": "重試"
+  },
+  "fire": {
+    "title": "FIRE 計算",
+    "description": "估算你的財務獨立目標金額與達標進度",
+    "assumptions": "假設參數",
+    "assumptionsHint": "留空的欄位會自動從你的資料推導，提示文字顯示目前推導值。",
+    "fields": {
+      "netWorth": "目前淨值（TWD）",
+      "annualExpenses": "年支出（TWD）",
+      "annualSavings": "年儲蓄（TWD）",
+      "expectedReturn": "預期年化報酬率",
+      "withdrawalRate": "安全提領率"
+    },
+    "apply": "套用",
+    "resetToAuto": "重設為自動",
+    "fireNumber": "FIRE 數字",
+    "progress": "達標進度",
+    "yearsToFI": "預估達標年數",
+    "yearsValue": "{years} 年",
+    "notOnTrack": "尚未在軌道上",
+    "projectionTitle": "淨值投影",
+    "projectionHint": "預估淨值與 FIRE 目標對照",
+    "yearAxis": "第 {year} 年",
+    "noSnapshotTitle": "尚無淨值資料",
+    "noSnapshotHint": "新增資產快照即可看到個人化投影，或於上方手動輸入淨值。"
   }
 }

--- a/frontend/src/app/fire/page.tsx
+++ b/frontend/src/app/fire/page.tsx
@@ -1,0 +1,247 @@
+/**
+ * FIRE 計算頁面
+ * 顯示 FIRE 數字、達標進度、預估達標年數，以及淨值與 FI 目標投影圖。
+ */
+
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import { AppLayout } from "@/components/layout/AppLayout";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
+import { Loading } from "@/components/ui/loading";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Money } from "@/components/common/Money";
+import {
+  Area,
+  ComposedChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+import { AlertCircle } from "lucide-react";
+import { useFireProjection } from "@/hooks/useFireProjection";
+import type { FireProjectionParams, FireProjectionResult } from "@/types/fire";
+
+type DraftKey = keyof FireProjectionParams;
+
+const DRAFT_FIELDS: DraftKey[] = [
+  "netWorth",
+  "annualExpenses",
+  "annualSavings",
+  "expectedReturn",
+  "withdrawalRate",
+];
+
+export default function FirePage() {
+  const t = useTranslations("fire");
+  const tCommon = useTranslations("common");
+  const tErrors = useTranslations("errors");
+
+  const [params, setParams] = useState<FireProjectionParams>({});
+  const [draft, setDraft] = useState<Record<DraftKey, string>>({
+    netWorth: "",
+    annualExpenses: "",
+    annualSavings: "",
+    expectedReturn: "",
+    withdrawalRate: "",
+  });
+
+  const { data, isLoading, isError } = useFireProjection(params);
+
+  const handleApply = () => {
+    const next: FireProjectionParams = {};
+    for (const key of DRAFT_FIELDS) {
+      const raw = draft[key].trim();
+      if (raw === "") continue;
+      const parsed = Number(raw);
+      if (!Number.isNaN(parsed)) next[key] = parsed;
+    }
+    setParams(next);
+  };
+
+  const handleReset = () => {
+    setDraft({
+      netWorth: "",
+      annualExpenses: "",
+      annualSavings: "",
+      expectedReturn: "",
+      withdrawalRate: "",
+    });
+    setParams({});
+  };
+
+  const progressValue =
+    data && data.fire_number > 0
+      ? Math.min(100, Math.max(0, data.progress_pct * 100))
+      : data
+        ? 100
+        : 0;
+
+  return (
+    <AppLayout title={t("title")} description={t("description")}>
+      <div className="space-y-6">
+        {/* 假設輸入表單 */}
+        <Card>
+          <CardHeader>
+            <CardTitle>{t("assumptions")}</CardTitle>
+            <CardDescription>{t("assumptionsHint")}</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-5">
+              {DRAFT_FIELDS.map((key) => (
+                <div key={key} className="space-y-2">
+                  <Label htmlFor={key}>{t(`fields.${key}`)}</Label>
+                  <Input
+                    id={key}
+                    inputMode="decimal"
+                    placeholder={
+                      data ? String(echoedValue(data, key)) : tCommon("loading")
+                    }
+                    value={draft[key]}
+                    onChange={(e) =>
+                      setDraft((d) => ({ ...d, [key]: e.target.value }))
+                    }
+                  />
+                </div>
+              ))}
+            </div>
+            <div className="mt-4 flex gap-2">
+              <Button onClick={handleApply}>{t("apply")}</Button>
+              <Button variant="outline" onClick={handleReset}>
+                {t("resetToAuto")}
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+
+        {isLoading && <Loading />}
+
+        {isError && (
+          <Alert variant="destructive">
+            <AlertCircle className="h-4 w-4" />
+            <AlertTitle>{tErrors("loadFailed")}</AlertTitle>
+            <AlertDescription>{tErrors("serverError")}</AlertDescription>
+          </Alert>
+        )}
+
+        {data && !isLoading && (
+          <>
+            {data.current_net_worth === 0 && (
+              <Alert>
+                <AlertCircle className="h-4 w-4" />
+                <AlertTitle>{t("noSnapshotTitle")}</AlertTitle>
+                <AlertDescription>{t("noSnapshotHint")}</AlertDescription>
+              </Alert>
+            )}
+
+            {/* 結果卡片 */}
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+              <Card>
+                <CardHeader>
+                  <CardDescription>{t("fireNumber")}</CardDescription>
+                  <CardTitle className="text-2xl">
+                    <Money value={data.fire_number} />
+                  </CardTitle>
+                </CardHeader>
+              </Card>
+              <Card>
+                <CardHeader>
+                  <CardDescription>{t("progress")}</CardDescription>
+                  <CardTitle className="text-2xl">
+                    {(data.progress_pct * 100).toFixed(1)}%
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <Progress value={progressValue} />
+                </CardContent>
+              </Card>
+              <Card>
+                <CardHeader>
+                  <CardDescription>{t("yearsToFI")}</CardDescription>
+                  <CardTitle className="text-2xl">
+                    {data.on_track && data.years_to_fi !== null
+                      ? t("yearsValue", { years: data.years_to_fi })
+                      : t("notOnTrack")}
+                  </CardTitle>
+                </CardHeader>
+              </Card>
+            </div>
+
+            {/* 投影圖 */}
+            <Card>
+              <CardHeader>
+                <CardTitle>{t("projectionTitle")}</CardTitle>
+                <CardDescription>{t("projectionHint")}</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <ResponsiveContainer width="100%" height={320}>
+                  <ComposedChart data={data.projection}>
+                    <CartesianGrid strokeDasharray="3 3" />
+                    <XAxis
+                      dataKey="year"
+                      tickFormatter={(y) => t("yearAxis", { year: y })}
+                    />
+                    <YAxis
+                      width={80}
+                      tickFormatter={(v) =>
+                        new Intl.NumberFormat("en", {
+                          notation: "compact",
+                        }).format(v as number)
+                      }
+                    />
+                    <Tooltip
+                      formatter={(value: number) =>
+                        new Intl.NumberFormat("en").format(value)
+                      }
+                    />
+                    <Area
+                      type="monotone"
+                      dataKey="projected_net_worth"
+                      name={t("fields.netWorth")}
+                      fill="hsl(var(--primary) / 0.2)"
+                      stroke="hsl(var(--primary))"
+                    />
+                    <Line
+                      type="monotone"
+                      dataKey="fire_target"
+                      name={t("fireNumber")}
+                      stroke="hsl(var(--destructive))"
+                      dot={false}
+                      strokeDasharray="5 5"
+                    />
+                  </ComposedChart>
+                </ResponsiveContainer>
+              </CardContent>
+            </Card>
+          </>
+        )}
+      </div>
+    </AppLayout>
+  );
+}
+
+function echoedValue(data: FireProjectionResult, key: DraftKey): number {
+  const map: Record<DraftKey, keyof FireProjectionResult> = {
+    netWorth: "current_net_worth",
+    annualExpenses: "annual_expenses",
+    annualSavings: "annual_savings",
+    expectedReturn: "expected_return",
+    withdrawalRate: "withdrawal_rate",
+  };
+  const v = data[map[key]];
+  return typeof v === "number" ? v : 0;
+}

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -22,6 +22,7 @@ import {
   RepeatIcon,
   ScaleIcon,
   BellIcon,
+  FlameIcon,
 } from "lucide-react";
 import {
   Sidebar,
@@ -108,6 +109,12 @@ export function AppLayout({ children, title, description }: AppLayoutProps) {
       label: t("rebalance"),
       icon: ScaleIcon,
       href: "/rebalance",
+    },
+    {
+      id: "fire",
+      label: t("fire"),
+      icon: FlameIcon,
+      href: "/fire",
     },
   ];
 

--- a/frontend/src/hooks/useFireProjection.ts
+++ b/frontend/src/hooks/useFireProjection.ts
@@ -1,0 +1,36 @@
+import { useQuery, type UseQueryOptions } from "@tanstack/react-query";
+import { fireAPI } from "@/lib/api/fire";
+import type { FireProjectionResult, FireProjectionParams } from "@/types/fire";
+import { APIError } from "@/lib/api/client";
+
+/**
+ * Query Keys
+ */
+export const fireKeys = {
+  all: ["fire"] as const,
+  projection: (params: FireProjectionParams) =>
+    [...fireKeys.all, "projection", params] as const,
+};
+
+/**
+ * 取得 FIRE 投影
+ *
+ * 省略的覆寫參數由後端自動推導。覆寫值變動時 query key 隨之改變並重新查詢。
+ *
+ * @param params 可選的覆寫參數
+ * @param options React Query 選項
+ */
+export function useFireProjection(
+  params: FireProjectionParams = {},
+  options?: Omit<
+    UseQueryOptions<FireProjectionResult, APIError>,
+    "queryKey" | "queryFn"
+  >
+) {
+  return useQuery<FireProjectionResult, APIError>({
+    queryKey: fireKeys.projection(params),
+    queryFn: () => fireAPI.getProjection(params),
+    staleTime: 1000 * 60 * 5,
+    ...options,
+  });
+}

--- a/frontend/src/lib/api/fire.ts
+++ b/frontend/src/lib/api/fire.ts
@@ -1,0 +1,25 @@
+import { apiClient } from "./client";
+import type { FireProjectionResult, FireProjectionParams } from "@/types/fire";
+
+/**
+ * FIRE API
+ * 提供 FIRE 投影相關的 API 呼叫
+ */
+export const fireAPI = {
+  /**
+   * 取得 FIRE 投影
+   *
+   * 未提供的參數由後端從應用資料自動推導（最新資產快照淨值、
+   * 近 12 個月現金流推導的年支出與年儲蓄）。
+   *
+   * @param params 可選的覆寫參數
+   * @returns FIRE 投影結果
+   */
+  getProjection: async (
+    params: FireProjectionParams = {}
+  ): Promise<FireProjectionResult> => {
+    return apiClient.get<FireProjectionResult>("/api/fire/projection", {
+      params: params as Record<string, number | undefined>,
+    });
+  },
+};

--- a/frontend/src/types/fire.ts
+++ b/frontend/src/types/fire.ts
@@ -1,0 +1,37 @@
+// FIRE (Financial Independence / Retire Early) 型別
+
+/**
+ * 投影圖表單一資料點
+ */
+export interface FireProjectionPoint {
+  year: number;
+  projected_net_worth: number;
+  fire_target: number;
+}
+
+/**
+ * FIRE 投影結果（後端回傳已套用的輸入值供前端回填）
+ */
+export interface FireProjectionResult {
+  current_net_worth: number;
+  annual_expenses: number;
+  annual_savings: number;
+  expected_return: number;
+  withdrawal_rate: number;
+  fire_number: number;
+  progress_pct: number;
+  years_to_fi: number | null;
+  on_track: boolean;
+  projection: FireProjectionPoint[];
+}
+
+/**
+ * 可選的覆寫參數；省略的欄位由後端自動推導。
+ */
+export interface FireProjectionParams {
+  netWorth?: number;
+  annualExpenses?: number;
+  annualSavings?: number;
+  expectedReturn?: number;
+  withdrawalRate?: number;
+}


### PR DESCRIPTION
## Summary

Closes #128

Adds a Ghostfolio-style FIRE (Financial Independence / Retire Early) calculator: a stateless backend endpoint plus a `/fire` frontend page that estimates the user's FIRE number, progress, and years to financial independence. Inputs auto-prefill from existing app data (latest asset snapshot net worth, trailing-12-month expenses/savings from the cash flow summary) and every assumption is overridable via query params.

## Changes

### Backend
- `internal/models/fire.go` — `FireProjectionInput` / `FireProjectionResult` / `FireProjectionPoint` and defaults (5% return, 4% withdrawal, 60-year cap).
- `internal/service/fire_service.go` — `FireService.GetProjection`; segregated `fireNetWorthSource` / `fireCashFlowSource` interfaces so it depends only on the methods it uses. Derives defaults only when an override is absent.
- `internal/api/fire_handler.go` — `GET /api/fire/projection`, auth-protected, optional float query params, `INVALID_WITHDRAWAL_RATE` -> 400.
- `cmd/api/main.go` — DI wiring (both startup paths) and route registration.

### Frontend
- `src/types/fire.ts`, `src/lib/api/fire.ts`, `src/hooks/useFireProjection.ts` (TanStack Query; query key includes overrides so edits refetch).
- `src/app/fire/page.tsx` — assumptions form (placeholders show derived values), stat cards (FI number, progress, years-to-FI / not-on-track), and a net-worth-vs-FI-target projection chart.
- Nav entry + i18n keys in `messages/en.json` and `messages/zh-TW.json`.

## Calculation

- `fireNumber = annualExpenses / withdrawalRate`
- `progressPct = currentNetWorth / fireNumber`
- `yearsToFI`: iterate `NW = NW*(1+r) + annualSavings` until `NW >= fireNumber`, capped at 60 years
- Edge cases: `annualSavings <= 0` -> `yearsToFI = null`, `onTrack = false`; `annualExpenses = 0` -> already FI; missing snapshot -> `currentNetWorth = 0`; `withdrawalRate <= 0` -> 400

## Test plan

- [x] `fire_service_test.go` — normal case, savings <= 0, expenses = 0, r = 0, override precedence, derive-from-deps, no-snapshot, 60-year cap
- [x] `fire_handler_test.go` — happy path, query override parsing, withdrawalRate <= 0 -> 400, unparseable params ignored
- [x] Backend `make test-unit` — 341 tests pass
- [x] Frontend `pnpm build` succeeds; `/fire` route present
- [x] FIRE-related files type-clean under `tsc --noEmit`

## Out of scope

FIRE variants (Lean/Fat/Coast/Barista), scenario sliders, persisted assumptions, dashboard widget.