### PR TITLE
fix(frontend): align FIRE page layout and zh-TW translations

### DIFF
--- a/frontend/messages/zh-TW.json
+++ b/frontend/messages/zh-TW.json
@@ -82,7 +82,7 @@
     "mainFeatures": "主要功能",
     "appName": "Asset Manager",
     "appDescription": "資產管理系統",
-    "fire": "FIRE"
+    "fire": "財務自由"
   },
   "dashboard": {
     "title": "首頁",
@@ -764,7 +764,7 @@
     "retry": "重試"
   },
   "fire": {
-    "title": "FIRE 計算",
+    "title": "財務自由試算",
     "description": "估算你的財務獨立目標金額與達標進度",
     "assumptions": "假設參數",
     "assumptionsHint": "留空的欄位會自動從你的資料推導，提示文字顯示目前推導值。",

--- a/frontend/src/app/fire/page.tsx
+++ b/frontend/src/app/fire/page.tsx
@@ -93,8 +93,9 @@ export default function FirePage() {
 
   return (
     <AppLayout title={t("title")} description={t("description")}>
-      <div className="space-y-6">
-        {/* 假設輸入表單 */}
+      <div className="flex-1 p-4 md:p-6 bg-muted">
+        <div className="flex flex-col gap-6">
+          {/* 假設輸入表單 */}
         <Card>
           <CardHeader>
             <CardTitle>{t("assumptions")}</CardTitle>
@@ -229,6 +230,7 @@ export default function FirePage() {
             </Card>
           </>
         )}
+        </div>
       </div>
     </AppLayout>
   );


### PR DESCRIPTION
## Summary

Follow-up fixes for the FIRE calculator page (from #128 / PR #129) reported after manual review.

- **Layout**: the `/fire` page used a bare `<div className="space-y-6">` wrapper, so it had no page padding or muted background and looked inconsistent with every other page. Now wrapped in the app convention `<div className="flex-1 p-4 md:p-6 bg-muted"><div className="flex flex-col gap-6">…</div></div>` (same as `/analytics`, `/rebalance`, `/holdings`, etc.).
- **i18n**: `nav.fire` and `fire.title` were left as English ("FIRE", "FIRE 計算") in `messages/zh-TW.json`, so the sidebar item and header stayed English while all other zh-TW labels are Chinese. Changed to `財務自由` (sidebar) and `財務自由試算` (header). English (`messages/en.json`) unchanged.

## Verification

- Playwright (zh-TW, logged in): sidebar shows `財務自由` consistent with other items; header `財務自由試算`; page renders with the muted/padded card layout matching `/analytics` (screenshots compared side by side).
- `pnpm tsc --noEmit`: no errors in changed files.

## Out of scope

The three review nits tracked in #130 (placeholder formatting, hardcoded chart locale, negative expectedReturn validation) are not addressed here.