### PR TITLE
build(deps): use Node 22 LTS for frontend image, guard non-LTS bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,6 +42,12 @@ updates:
     labels:
       - "dependencies"
       - "docker"
+    # Stay on a Node.js LTS line. Allow 22.x updates (incl. digest/patch);
+    # block jumps to 23+ (non-LTS Current) so moving LTS lines stays a
+    # manual, deliberate decision.
+    ignore:
+      - dependency-name: "node"
+        versions: [">22"]
 
   - package-ecosystem: "docker"
     directory: "/backend"

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,6 @@
 # 多階段建置 Dockerfile for Next.js Frontend
 # Stage 1: 依賴安裝階段
-FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293 AS deps
+FROM node:22-alpine@sha256:968df39aedcea65eeb078fb336ed7191baf48f972b4479711397108be0966920 AS deps
 
 # 安裝 pnpm
 RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
@@ -14,7 +14,7 @@ COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile
 
 # Stage 2: 建置階段
-FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293 AS builder
+FROM node:22-alpine@sha256:968df39aedcea65eeb078fb336ed7191baf48f972b4479711397108be0966920 AS builder
 
 # 安裝 pnpm
 RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
@@ -39,7 +39,7 @@ ENV NODE_OPTIONS="--max-old-space-size=1024"
 RUN pnpm build
 
 # Stage 3: 執行階段
-FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293 AS runner
+FROM node:22-alpine@sha256:968df39aedcea65eeb078fb336ed7191baf48f972b4479711397108be0966920 AS runner
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

Replaces Dependabot PR #111 (which proposed `node:20-alpine` -> `node:25-alpine`). Node 25 is a non-LTS "Current" release and is unsuitable for a production base image.

- `frontend/Dockerfile`: bump all three stages (`deps`, `builder`, `runner`) from `node:20-alpine` to `node:22-alpine` (current Active LTS), digest-pinned to `sha256:968df39aedcea65eeb078fb336ed7191baf48f972b4479711397108be0966920` (the `node:22-alpine` index digest).
- `.github/dependabot.yml`: add an `ignore` rule on the `/frontend` docker ecosystem for `node` `versions: [">22"]`, so future bumps stay within the 22.x LTS line (digest/patch updates still flow) and moving to a newer LTS remains a deliberate manual decision rather than an automatic jump to a non-LTS Current release.

Closes #111 will be handled by closing that PR separately with a pointer here.

## Verification

- `node:22-alpine` index digest resolved via `docker buildx imagetools inspect`.
- `.github/dependabot.yml` validated as well-formed YAML.
- Frontend Docker image build with Node 22 validated locally (see PR comment with result).
- Node 22 is LTS and fully supports the project's Next.js 16 frontend; README "Prerequisites" (Node >= 18) remains satisfied.

## Out of scope

Backend Docker image and other ecosystems are unchanged.