### PR TITLE
ci: unblock deploy workflow (pnpm 10, test serialization, swagger spec)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ on:
 env:
   GO_VERSION: "1.25"
   NODE_VERSION: "20"
-  PNPM_VERSION: "9"
+  PNPM_VERSION: "10"
 
 jobs:
   # Job 1: 通知 - 部署開始
@@ -125,7 +125,10 @@ jobs:
           TEST_DB_PASSWORD: postgres
           TEST_DB_NAME: asset_manager_test
         run: |
-          gotestsum --format testname -- -cover ./...
+          # -p 1 serializes package test binaries: repository/BDD suites share
+          # one Postgres test DB and TRUNCATE ... CASCADE concurrently, which
+          # deadlocks (pq 40P01) when packages run in parallel.
+          gotestsum --format testname -- -p 1 -cover ./...
 
       - name: 📝 Install swag CLI
         run: go install github.com/swaggo/swag/cmd/swag@v1.16.4

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -3872,6 +3872,73 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/fire/projection": {
+            "get": {
+                "description": "依據自動推導的淨值與現金流（可由查詢參數覆寫）計算 FIRE 數字、進度與達標年數",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "fire"
+                ],
+                "summary": "取得 FIRE 投影",
+                "parameters": [
+                    {
+                        "type": "number",
+                        "description": "目前淨值（TWD），覆寫最新資產快照",
+                        "name": "netWorth",
+                        "in": "query"
+                    },
+                    {
+                        "type": "number",
+                        "description": "年支出（TWD），覆寫近 12 個月推導值",
+                        "name": "annualExpenses",
+                        "in": "query"
+                    },
+                    {
+                        "type": "number",
+                        "description": "年儲蓄（TWD），覆寫近 12 個月推導值",
+                        "name": "annualSavings",
+                        "in": "query"
+                    },
+                    {
+                        "type": "number",
+                        "description": "預期年化報酬率（小數），預設 0.05",
+                        "name": "expectedReturn",
+                        "in": "query"
+                    },
+                    {
+                        "type": "number",
+                        "description": "安全提領率（小數），預設 0.04",
+                        "name": "withdrawalRate",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_chienchuanw_asset-manager_internal_models.FireProjectionResult"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/internal_api.APIResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_api.APIResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/holdings": {
             "get": {
                 "description": "取得所有持倉列表，支援按資產類型和標的代碼篩選",
@@ -7724,6 +7791,58 @@ const docTemplate = `{
                 },
                 "yearly_report_month": {
                     "description": "每年幾月發送 (1-12)",
+                    "type": "integer"
+                }
+            }
+        },
+        "github_com_chienchuanw_asset-manager_internal_models.FireProjectionPoint": {
+            "type": "object",
+            "properties": {
+                "fire_target": {
+                    "type": "number"
+                },
+                "projected_net_worth": {
+                    "type": "number"
+                },
+                "year": {
+                    "type": "integer"
+                }
+            }
+        },
+        "github_com_chienchuanw_asset-manager_internal_models.FireProjectionResult": {
+            "type": "object",
+            "properties": {
+                "annual_expenses": {
+                    "type": "number"
+                },
+                "annual_savings": {
+                    "type": "number"
+                },
+                "current_net_worth": {
+                    "type": "number"
+                },
+                "expected_return": {
+                    "type": "number"
+                },
+                "fire_number": {
+                    "type": "number"
+                },
+                "on_track": {
+                    "type": "boolean"
+                },
+                "progress_pct": {
+                    "type": "number"
+                },
+                "projection": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_chienchuanw_asset-manager_internal_models.FireProjectionPoint"
+                    }
+                },
+                "withdrawal_rate": {
+                    "type": "number"
+                },
+                "years_to_fi": {
                     "type": "integer"
                 }
             }

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -3866,6 +3866,73 @@
                 }
             }
         },
+        "/api/fire/projection": {
+            "get": {
+                "description": "依據自動推導的淨值與現金流（可由查詢參數覆寫）計算 FIRE 數字、進度與達標年數",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "fire"
+                ],
+                "summary": "取得 FIRE 投影",
+                "parameters": [
+                    {
+                        "type": "number",
+                        "description": "目前淨值（TWD），覆寫最新資產快照",
+                        "name": "netWorth",
+                        "in": "query"
+                    },
+                    {
+                        "type": "number",
+                        "description": "年支出（TWD），覆寫近 12 個月推導值",
+                        "name": "annualExpenses",
+                        "in": "query"
+                    },
+                    {
+                        "type": "number",
+                        "description": "年儲蓄（TWD），覆寫近 12 個月推導值",
+                        "name": "annualSavings",
+                        "in": "query"
+                    },
+                    {
+                        "type": "number",
+                        "description": "預期年化報酬率（小數），預設 0.05",
+                        "name": "expectedReturn",
+                        "in": "query"
+                    },
+                    {
+                        "type": "number",
+                        "description": "安全提領率（小數），預設 0.04",
+                        "name": "withdrawalRate",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_chienchuanw_asset-manager_internal_models.FireProjectionResult"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/internal_api.APIResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_api.APIResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/holdings": {
             "get": {
                 "description": "取得所有持倉列表，支援按資產類型和標的代碼篩選",
@@ -7718,6 +7785,58 @@
                 },
                 "yearly_report_month": {
                     "description": "每年幾月發送 (1-12)",
+                    "type": "integer"
+                }
+            }
+        },
+        "github_com_chienchuanw_asset-manager_internal_models.FireProjectionPoint": {
+            "type": "object",
+            "properties": {
+                "fire_target": {
+                    "type": "number"
+                },
+                "projected_net_worth": {
+                    "type": "number"
+                },
+                "year": {
+                    "type": "integer"
+                }
+            }
+        },
+        "github_com_chienchuanw_asset-manager_internal_models.FireProjectionResult": {
+            "type": "object",
+            "properties": {
+                "annual_expenses": {
+                    "type": "number"
+                },
+                "annual_savings": {
+                    "type": "number"
+                },
+                "current_net_worth": {
+                    "type": "number"
+                },
+                "expected_return": {
+                    "type": "number"
+                },
+                "fire_number": {
+                    "type": "number"
+                },
+                "on_track": {
+                    "type": "boolean"
+                },
+                "progress_pct": {
+                    "type": "number"
+                },
+                "projection": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_chienchuanw_asset-manager_internal_models.FireProjectionPoint"
+                    }
+                },
+                "withdrawal_rate": {
+                    "type": "number"
+                },
+                "years_to_fi": {
                     "type": "integer"
                 }
             }

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -715,6 +715,40 @@ definitions:
         description: 每年幾月發送 (1-12)
         type: integer
     type: object
+  github_com_chienchuanw_asset-manager_internal_models.FireProjectionPoint:
+    properties:
+      fire_target:
+        type: number
+      projected_net_worth:
+        type: number
+      year:
+        type: integer
+    type: object
+  github_com_chienchuanw_asset-manager_internal_models.FireProjectionResult:
+    properties:
+      annual_expenses:
+        type: number
+      annual_savings:
+        type: number
+      current_net_worth:
+        type: number
+      expected_return:
+        type: number
+      fire_number:
+        type: number
+      on_track:
+        type: boolean
+      progress_pct:
+        type: number
+      projection:
+        items:
+          $ref: '#/definitions/github_com_chienchuanw_asset-manager_internal_models.FireProjectionPoint'
+        type: array
+      withdrawal_rate:
+        type: number
+      years_to_fi:
+        type: integer
+    type: object
   github_com_chienchuanw_asset-manager_internal_models.FixInsufficientQuantityInput:
     properties:
       current_holding:
@@ -4047,6 +4081,50 @@ paths:
       summary: 更新今日匯率
       tags:
       - exchange-rates
+  /api/fire/projection:
+    get:
+      consumes:
+      - application/json
+      description: 依據自動推導的淨值與現金流（可由查詢參數覆寫）計算 FIRE 數字、進度與達標年數
+      parameters:
+      - description: 目前淨值（TWD），覆寫最新資產快照
+        in: query
+        name: netWorth
+        type: number
+      - description: 年支出（TWD），覆寫近 12 個月推導值
+        in: query
+        name: annualExpenses
+        type: number
+      - description: 年儲蓄（TWD），覆寫近 12 個月推導值
+        in: query
+        name: annualSavings
+        type: number
+      - description: 預期年化報酬率（小數），預設 0.05
+        in: query
+        name: expectedReturn
+        type: number
+      - description: 安全提領率（小數），預設 0.04
+        in: query
+        name: withdrawalRate
+        type: number
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_chienchuanw_asset-manager_internal_models.FireProjectionResult'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/internal_api.APIResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/internal_api.APIResponse'
+      summary: 取得 FIRE 投影
+      tags:
+      - fire
   /api/holdings:
     get:
       consumes:


### PR DESCRIPTION
## Summary

The "Deploy to Production (AWS EC2)" workflow failed on every push to `main`. Three independent root causes, fixed in order as each unblocked the next:

### 1. Frontend tests — `pnpm install`: `ERROR packages field missing or empty`

`deploy.yml` pinned `PNPM_VERSION: "9"`. `frontend/pnpm-workspace.yaml` (added in 2922599 "for pnpm 11"; only an `allowBuilds:` map, no `packages:` field) is invalid under pnpm 9. Fix: `PNPM_VERSION` `"9"` -> `"10"`, matching the `pnpm 10.33.0` already pinned in `security-audit.yml`. (Verified locally this session.)

### 2. Backend tests — `pq: deadlock detected (40P01)`

`gotestsum -- -cover ./...` runs package test binaries in parallel; the `repository` and BDD `features` suites share one Postgres test DB and each run `TRUNCATE ... CASCADE`, deadlocking under concurrency. Fix: add `-p 1` to serialize package binaries (commented in the workflow). Pre-existing latent flake, unrelated to recent feature work.

### 3. Backend job — swagger freshness gate failed

Once tests passed, the job reached its final step: `swag init ... && git diff --exit-code docs/`. The FIRE feature added `@Router /api/fire/projection [get]` annotations but the committed `backend/docs/` spec was never regenerated. Fix: regenerated with `swag@v1.16.4` (exact CI version) — `backend/docs/{docs.go,swagger.json,swagger.yaml}` now include the FIRE endpoint (+316 lines, additions only). Note: `backend/docs` is covered by the repo-wide `docs` gitignore rule but these files are already tracked (committed before the rule), so they were force-added; CI's `git diff` tracks them regardless.

## Verification

- `deploy.yml` validated as well-formed YAML.
- Latest `main` deploy run (after fix 1+2) confirmed: "Run Frontend Tests" now passes and backend tests pass (`DONE 846 tests`, no failures) — only the swagger gate remained, which fix 3 addresses.
- Swagger regenerated with the pinned `swag@v1.16.4`; diff is additive only (no version-drift churn), so CI's `git diff --exit-code` will be clean.

## Notes

- The deploy workflow only triggers on push to `main`, so this PR's checks (security-audit) cannot exercise these fixes; they prove out on the next `main` deploy.
- `security-audit.yml` already pins pnpm `10.33.0` — unaffected.
- Deeper future hardening (per-test isolated schemas / dropping unnecessary `TRUNCATE CASCADE`) noted as out of scope.